### PR TITLE
[watch/rebar 1/3] Fix gdb.rocm/watch-gpu-global-from-host.exp on non-ReBAR systems

### DIFF
--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -43,9 +43,14 @@ proc do_test {} {
 
 	gdb_test "watch global" "Hardware watchpoint $::decimal: global"
 
-	gdb_test "continue" \
-	    "Hardware watchpoint $::decimal: global.*Old value = 0\r\nNew value = 8\r\nmain.*" \
-	    "hit watchpoint in main"
+	gdb_test_multiple "continue" "hit watchpoint in main" {
+	    -re -wrap "Hardware watchpoint $::decimal: global.*Old value = 0\r\nNew value = 8\r\nmain.*" {
+		pass $gdb_test_name
+	    }
+	    -re -wrap "received signal SIGSEGV, .*\\*devGlobal = 8;.*" {
+		unsupported "$gdb_test_name (not mapped on cpu)"
+	    }
+	}
     }
 }
 


### PR DESCRIPTION
On a system with Resizable BAR (ReBAR) enabled, the BAR size is the
size of the whole VRAM, so the runtime is able to allocate rw mappings
on the CPU that map to /dev/dri/render nodes, and have __device__
variables mapped there.  This means that on ReBAR systems, __device__
variables as directly host-accessible.

If ReBAR is off, though, the runtime can't do that, the BAR window is
only 256MB, and the runtime will only allocate CPU-visible rw mappings
for VRAM selectively, for managed memory, and not for __device__
variables.

So on a non-ReBAR system, accessing __device__ variables from the CPU
side segfaults, and so gdb.rocm/watch-gpu-global-from-host.exp fails
with:

Thread 1 "watch-gpu-globa" received signal SIGSEGV, Segmentation fault.
[Switching to thread 1 (Thread 0x7ffff62d0f80 (LWP 590038))]
0x0000000000211c43 in main (argc=1, argv=0x7fffffffcf88) at /home/pedro/rocm/gdb/build/gdb/testsuite/../../../src/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp:39
39        *devGlobal = 8;
(gdb) FAIL: gdb.rocm/watch-gpu-global-from-host.exp: hit watchpoint in main

I tried several approaches to try to determine whether the access
would work, before the access:

- I tried several HIP APIs, but none work reliably.

- I also tried making the testcase find the mapping that corresponds
to the pointer, and check the mapping permissions, and it works, but
then that's linux specific, and for Windows we'd need something
else, or hardcode that the CPU can never access VRAM directly there,
at least currently.

In the end, I concluded that just letting the access happen and seeing
the SIGSEGV is the best and simplest and the most portable, and
doesn't really have a downside.

So that's what this commit uses to detect the situation, and issue
UNSUPPORTED.

Tested on Linux ReBAR on and off, and on Windows.

Change-Id: I052f2858357ef34d0dbaaa6479d5131571cea112

---

**Stack**:
- #82
- #81
- #80 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*