### PR TITLE
[watch/rebar 3/3] New gdb.rocm/watch-managed-device-host.exp test

### DIFF
--- a/gdb/testsuite/gdb.rocm/watch-managed-device-host.cpp
+++ b/gdb/testsuite/gdb.rocm/watch-managed-device-host.cpp
@@ -1,0 +1,137 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <hip/hip_runtime.h>
+#include <string.h>
+#include <stdio.h>
+#include <iostream>
+#include "rocm-test-utils.h"
+
+__global__ void
+kern (int *ptr)
+{
+  *ptr = 1;
+  WAIT_MEM;
+}
+
+int *managed_ptr = nullptr;
+
+enum residency_mode
+{
+  /* Bias toward VRAM, CPU-accessible.  */
+  DEVICE,
+  /* Bias toward system memory, GPU-accessible.  */
+  HOST,
+};
+
+/* Like CHECK, but don't error out if the arguments to the call are
+   unsupported.  Used with the hipMemAdvise hints below.  */
+#define CHECK_IGNORE_UNSUPPORTED(cmd)					\
+  do									\
+    {									\
+      hipError_t err = cmd;						\
+      if (err != hipSuccess && err != hipErrorInvalidValue)		\
+	CHECK (err);							\
+    }									\
+  while (0)
+
+/* The hipMemAdvise hints may not be supported on Windows.  */
+#ifdef _WIN32
+# define CHECK_MAYBE_IGNORE_UNSUPPORTED CHECK_IGNORE_UNSUPPORTED
+#else
+# define CHECK_MAYBE_IGNORE_UNSUPPORTED CHECK
+#endif
+
+/* Apply RESIDENCY to PTR.  */
+
+static void
+apply_residency (int *ptr, enum residency_mode residency)
+{
+  constexpr int device_id = 0;
+
+  int resident_id;
+  int other_id;
+  if (residency == DEVICE)
+    {
+      resident_id = device_id;
+      other_id = hipCpuDeviceId;
+    }
+  else
+    {
+      resident_id = hipCpuDeviceId;
+      other_id = device_id;
+    }
+
+  CHECK_MAYBE_IGNORE_UNSUPPORTED
+    (hipMemAdvise (ptr, sizeof (int), hipMemAdviseSetPreferredLocation,
+		   resident_id));
+
+  CHECK_MAYBE_IGNORE_UNSUPPORTED
+    (hipMemAdvise (ptr, sizeof (int), hipMemAdviseSetAccessedBy,
+		   other_id));
+
+  /* Establish residency on RESIDENT_ID device.  */
+  CHECK (hipMemPrefetchAsync (ptr, sizeof (int), resident_id, 0));
+  CHECK (hipDeviceSynchronize ());
+}
+
+int
+main (int argc, char **argv)
+{
+  if (argc != 2)
+    {
+      std::cerr
+	<< "Usage: " << argv[0] << " device|host" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  const char *residency_str = argv[1];
+  residency_mode residency;
+
+  if (strcmp (residency_str, "device") == 0)
+    residency = DEVICE;
+  else if (strcmp (residency_str, "host") == 0)
+    residency = HOST;
+  else
+    {
+      std::cerr << "Unsupported residency " << residency_str << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  CHECK (hipMallocManaged (&managed_ptr, sizeof (int)));
+
+  apply_residency (managed_ptr, residency); /* set break 1 here */
+
+  /* Warm up GPU and trigger initial watchpoint in kernel.  */
+  kern<<<1, 1>>> (managed_ptr);
+  CHECK (hipDeviceSynchronize ());
+
+  /* Re-establish residency in case debugger or kernel access caused
+     migration.  */
+  apply_residency (managed_ptr, residency); /* set break 2 here */
+
+  printf ("Pointer address: %p\n", (void *) managed_ptr);
+  printf ("Attempting host write (watchpoint expected)...\n");
+
+  /* Trigger watchpoint from the host.  */
+  *managed_ptr = 2;
+
+  printf ("Write successful.  Value: %d\n", *managed_ptr);
+
+  CHECK (hipFree (managed_ptr));
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/watch-managed-device-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-managed-device-host.exp
@@ -1,0 +1,94 @@
+# Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test triggering watchpoints on device and host writes, of
+# device/vram and host/system memory.  I.e.:
+#
+# - device write vram
+# - device write system memory
+# - host write vram
+# - host write system memory
+#
+# Test all the scenarios above in combination with setting watchpoint
+# both from device or host context.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+
+standard_testfile .cpp
+
+if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+proc do_test {residency set_watch_from} {
+    clean_restart
+    gdb_load $::binfile
+
+    with_rocm_gpu_lock {
+	gdb_test_no_output "set args $residency"
+
+	if {$set_watch_from == "device"} {
+	    if {![runto kern allow-pending message]} {
+		return
+	    }
+
+	    set watch_expr "-location *ptr"
+	} else {
+	    if {![runto [gdb_get_line_number "break 1 here"] allow-pending message]} {
+		return
+	    }
+
+	    set watch_expr "-location *managed_ptr"
+	}
+
+	set watch_expr_re [string_to_regexp $watch_expr]
+
+	gdb_test "watch $watch_expr" \
+	    "Hardware watchpoint $::decimal: $watch_expr_re"
+
+	# Test that the watchpoint hits from the device side.
+
+	# Set a guard breakpoint, so that if the device watchpoint
+	# doesn't fire, we don't stop at the host watchpoint access,
+	# confusing the host watchpoint test below.
+	gdb_breakpoint [gdb_get_line_number "break 2 here"]
+
+	gdb_test_multiple "continue" "hit watchpoint in kern" {
+	    -re -wrap "Hardware watchpoint $::decimal: $watch_expr_re.*Old value = 0\r\nNew value = 1\r\n($::hex in )?kern.*" {
+		pass $gdb_test_name
+	    }
+	    -re -wrap "break 2 here.*" {
+		fail $gdb_test_name
+	    }
+	}
+	gdb_test_no_output "delete \$bpnum" "delete guard breakpoint"
+
+	# Test that the watchpoint hits from the host side.  Ignore
+	# old value, in case the kernel side watchpoint failed to hit
+	# earlier.
+
+	gdb_test "continue" \
+	    "Hardware watchpoint $::decimal: $watch_expr_re.*Old value = $::decimal\r\nNew value = 2\r\nmain.*" \
+	    "hit watchpoint in main"
+    }
+}
+
+foreach_with_prefix residency { device host } {
+    foreach_with_prefix set_watch_from { device host } {
+	do_test $residency $set_watch_from
+    }
+}


### PR DESCRIPTION
This adds a new testcase that exercises triggering watchpoints on
device and host writes, of device/vram and host/system memory, using
hipMallocManaged.  I.e.:

- device write of vram
- device write of system memory
- host write of vram
- host write of system memory

It tests all the scenarios above in combination with setting
watchpoint both from device or from host context.

Unlike gdb.rocm/watch-gpu-global-from-host.exp, since this uses
managed memory, this one works on non-ReBAR systems too.

Tested on Linux gfx942, Linux gfx1030 with ReBAR off, and on Windows
gfx1201.

Change-Id: I4d167e42b0a712583d842045274d6db64ba7a7a0

---

**Stack**:
- #82 ⬅
- #81
- #80


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*