### PR TITLE
HIP ramifications: rename language_cplus to language_cplus_

### DIFF
--- a/gdb/breakpoint.c
+++ b/gdb/breakpoint.c
@@ -3969,7 +3969,7 @@ create_std_terminate_master_breakpoint (void)
   const char *const func_name = "std::terminate()";
 
   scoped_restore_current_program_space restore_pspace;
-  scoped_restore_current_language save_language (language_cplus);
+  scoped_restore_current_language save_language (language_cplus_);
 
   for (struct program_space *pspace : program_spaces)
     {

--- a/gdb/c-lang.c
+++ b/gdb/c-lang.c
@@ -865,7 +865,7 @@ class cplus_language : public language_defn
 {
 public:
   cplus_language ()
-    : language_defn (language_cplus)
+    : language_defn (language_cplus_)
   { /* Nothing.  */ }
 
   /* See language.h.  */

--- a/gdb/c-typeprint.c
+++ b/gdb/c-typeprint.c
@@ -256,7 +256,7 @@ cp_type_print_method_args (struct type *mtype,
   int i;
 
   fprintf_symbol (stream, varstring,
-		  language_cplus, DMGL_ANSI);
+		  language_cplus_, DMGL_ANSI);
   gdb_puts ("(", stream);
 
   int printed_args = 0;

--- a/gdb/compile/compile.c
+++ b/gdb/compile/compile.c
@@ -539,7 +539,7 @@ get_language_compile_context ()
     {
     case language_c:
       return c_get_compile_context ();
-    case language_cplus:
+    case language_cplus_:
       return cplus_get_compile_context ();
     default:
       return {};
@@ -558,7 +558,7 @@ compute_program_language (compile_instance *inst, const char *input,
     {
     case language_c:
       return c_compute_program (inst, input, gdbarch, block, pc);
-    case language_cplus:
+    case language_cplus_:
       return cplus_compute_program (inst, input, gdbarch, block, pc);
     default:
       gdb_assert_not_reached ("Unsupported language");

--- a/gdb/cp-namespace.c
+++ b/gdb/cp-namespace.c
@@ -559,7 +559,7 @@ cp_lookup_symbol_imports (const char *scope,
 	{
 	  struct type *context;
 	  std::string name_copy (function->natural_name ());
-	  const struct language_defn *lang = language_def (language_cplus);
+	  const struct language_defn *lang = language_def (language_cplus_);
 	  const struct block *parent = block->superblock ();
 	  struct symbol *sym;
 

--- a/gdb/cp-support.c
+++ b/gdb/cp-support.c
@@ -1873,7 +1873,7 @@ cp_symbol_name_matches_1 (const char *symbol_search_name,
   while (true)
     {
       if (strncmp_iw_with_mode (sname, lookup_name, lookup_name_len,
-				mode, language_cplus, match_for_lcd, true) == 0)
+				mode, language_cplus_, match_for_lcd, true) == 0)
 	{
 	  if (comp_match_res != NULL)
 	    {
@@ -1936,7 +1936,7 @@ cp_fq_symbol_name_matches (const char *symbol_search_name,
 
   if (strncmp_iw_with_mode (symbol_search_name,
 			    name.c_str (), name.size (),
-			    mode, language_cplus, match_for_lcd) == 0)
+			    mode, language_cplus_, match_for_lcd) == 0)
     {
       if (comp_match_res != NULL)
 	comp_match_res->set_match (symbol_search_name);

--- a/gdb/defs.h
+++ b/gdb/defs.h
@@ -116,7 +116,7 @@ enum language
     language_c,			/* C */
     language_objc,		/* Objective-C */
     language_rust,		/* Rust */
-    language_cplus,		/* C++ */
+    language_cplus_,		/* C++ */
     language_hip,		/* HIP (Heterogeneous Interface for Portability) */
     language_d,			/* D */
     language_go,		/* Go */
@@ -143,7 +143,7 @@ static_assert (nr_languages <= (1 << LANGUAGE_BITS));
 static inline bool
 is_cplus_dialect (enum language lang)
 {
-  return lang == language_cplus || lang == language_hip;
+  return lang == language_cplus_ || lang == language_hip;
 }
 
 /* If LANG is one of C++ dialects, return "language_cplus".
@@ -152,7 +152,7 @@ is_cplus_dialect (enum language lang)
 static inline enum language
 strip_cplus_dialect (enum language lang)
 {
-  return is_cplus_dialect (lang) ? language_cplus : lang;
+  return is_cplus_dialect (lang) ? language_cplus_ : lang;
 }
 
 /* * A generic, not quite boolean, enumeration.  This is used for

--- a/gdb/dwarf2/cooked-index-entry.c
+++ b/gdb/dwarf2/cooked-index-entry.c
@@ -183,7 +183,7 @@ cooked_index_entry::full_name (struct obstack *storage,
   const char *sep = default_sep;
   switch (strip_cplus_dialect (lang))
     {
-    case language_cplus:
+    case language_cplus_:
     case language_rust:
     case language_fortran:
       sep = "::";

--- a/gdb/dwarf2/read-gdb-index.c
+++ b/gdb/dwarf2/read-gdb-index.c
@@ -232,13 +232,13 @@ mapped_gdb_index::build_name_components (dwarf2_per_objfile *per_objfile)
       if (strstr (name, "::") != nullptr)
 	{
 	  components = split_name (name, split_style::CXX);
-	  lang = language_cplus;
+	  lang = language_cplus_;
 	}
       else if (strchr (name, '<') != nullptr)
 	{
 	  /* Guess that this is a template and so a C++ name.  */
 	  components.emplace_back (name);
-	  lang = language_cplus;
+	  lang = language_cplus_;
 	}
       else if (strstr (name, "__") != nullptr)
 	{
@@ -299,7 +299,7 @@ mapped_gdb_index::build_name_components (dwarf2_per_objfile *per_objfile)
 	      else
 		{
 		  tag = DW_TAG_structure_type;
-		  this_lang = language_cplus;
+		  this_lang = language_cplus_;
 		}
 	      break;
 	      /* The "default" should not happen, but we mention it to

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -13615,7 +13615,7 @@ read_subrange_type (struct die_info *die, struct dwarf2_cu *cu)
   switch (strip_cplus_dialect (cu->lang ()))
     {
     case language_c:
-    case language_cplus:
+    case language_cplus_:
       low.set_const_val (0);
       low_default_is_valid = 1;
       break;
@@ -14049,7 +14049,7 @@ cooked_index_functions::search
     /* No splitting is also a style.  */
     language_c,
     /* This includes Rust.  */
-    language_cplus,
+    language_cplus_,
     /* This includes Go.  */
     language_d,
     language_ada
@@ -14068,9 +14068,9 @@ cooked_index_functions::search
 
 	switch (strip_cplus_dialect (lang))
 	  {
-	  case language_cplus:
+	  case language_cplus_:
 	  case language_rust:
-	    unique_styles_used[language_cplus] = true;
+	    unique_styles_used[language_cplus_] = true;
 	    break;
 	  case language_d:
 	  case language_go:
@@ -15075,7 +15075,7 @@ dwarf_lang_to_enum_language (ULONGEST lang)
     case DW_LANG_C_plus_plus_17:
     case DW_LANG_C_plus_plus_20:
     case DW_LANG_C_plus_plus_23:
-      language = language_cplus;
+      language = language_cplus_;
       break;
     case DW_LANG_D:
       language = language_d;
@@ -18249,7 +18249,7 @@ cutu_reader::prepare_one_comp_unit (struct dwarf2_cu *cu,
 	     with a "set language hip" command in GDB itself.  Still, this
 	     workaround works better than checking the "producer", since
 	     various providers tend to name them slightly differently.  */
-	  if (lang == language_cplus
+	  if (lang == language_cplus_
 	      && (cu->per_objfile->per_bfd->obfd->arch_info->arch
 		  == bfd_arch_amdgcn))
 	    {

--- a/gdb/eval.c
+++ b/gdb/eval.c
@@ -286,7 +286,7 @@ binop_promote (const struct language_defn *language, struct gdbarch *gdbarch,
       switch (strip_cplus_dialect (language->la_language))
 	{
 	case language_c:
-	case language_cplus:
+	case language_cplus_:
 	case language_asm:
 	case language_objc:
 	case language_opencl:

--- a/gdb/source-cache.c
+++ b/gdb/source-cache.c
@@ -153,7 +153,7 @@ get_language_name (enum language lang)
     case language_objc:
       return "c.lang";
 
-    case language_cplus:
+    case language_cplus_:
       return "cpp.lang";
 
     case language_d:

--- a/gdb/symtab.c
+++ b/gdb/symtab.c
@@ -1052,7 +1052,7 @@ general_symbol_info::natural_name () const
 {
   switch (strip_cplus_dialect (language ()))
     {
-    case language_cplus:
+    case language_cplus_:
     case language_d:
     case language_go:
     case language_objc:
@@ -1078,7 +1078,7 @@ general_symbol_info::demangled_name () const
 
   switch (strip_cplus_dialect (language ()))
     {
-    case language_cplus:
+    case language_cplus_:
     case language_d:
     case language_go:
     case language_objc:

--- a/gdb/symtab.h
+++ b/gdb/symtab.h
@@ -275,7 +275,7 @@ class lookup_name_info final
       {
       case language_ada:
 	return ada ().lookup_name ().c_str ();
-      case language_cplus:
+      case language_cplus_:
 	return cplus ().lookup_name ().c_str ();
       case language_d:
 	return d ().lookup_name ().c_str ();
@@ -295,7 +295,7 @@ class lookup_name_info final
     split_style style = split_style::NONE;
     switch (strip_cplus_dialect (lang))
       {
-      case language_cplus:
+      case language_cplus_:
       case language_rust:
 	style = split_style::CXX;
 	break;
@@ -317,7 +317,7 @@ class lookup_name_info final
   /* Get the C++-specific lookup info.  */
   const demangle_for_lookup_info &cplus () const
   {
-    maybe_init (m_cplus, language_cplus);
+    maybe_init (m_cplus, language_cplus_);
     return *m_cplus;
   }
 

--- a/gdb/unittests/lookup_name_info-selftests.c
+++ b/gdb/unittests/lookup_name_info-selftests.c
@@ -102,7 +102,7 @@ run_tests ()
 	     "Foozle<int>::fogey<Empty<int> >");
     };
 
-  check_cpp_dialect (language_cplus);
+  check_cpp_dialect (language_cplus_);
   check_cpp_dialect (language_hip);
 
 #undef CHECK

--- a/gdb/utils.c
+++ b/gdb/utils.c
@@ -2812,7 +2812,7 @@ strncmp_iw_with_mode_tests ()
 
   /* Test scope operator.  */
   check_scope_operator (language_minimal);
-  check_scope_operator (language_cplus);
+  check_scope_operator (language_cplus_);
   check_scope_operator (language_fortran);
   check_scope_operator (language_rust);
 
@@ -2856,7 +2856,7 @@ strncmp_iw_with_mode_tests ()
 #undef MATCH
     };
 
-  user_def_ops_test (language_cplus);
+  user_def_ops_test (language_cplus_);
   user_def_ops_test (language_hip);
 
   /* Skip "[abi:cxx11]" tags in the symbol name if the lookup name


### PR DESCRIPTION
After the introduction of

  https://github.com/ROCm/ROCgdb/commit/63ebd1ad66c5ca8b7b72aec41892eb74e0f8989e gdb/language: add "is_cplus_dialect ()" check
  https://github.com/ROCm/ROCgdb/commit/8d269b60f687e0fdaae8a3d960b6bb499eaf67f0 gdb/language: add "strip_cplus_dialect ()"

that for the benefit of the HIP language, try to group C++-like
languages together, there can easily be an oversight when
upstream changes introduce new instances of language_cplus
into the code base.  This patch renames the (downstream)
language_cplus, so that such new instances are caught by build
failures.

When the build fails, given the context, there are 3 possible
outcomes:

1) Using "is_cplus_dialect (...)" instead
2) Using "strip_cplus_dialect (...)", followed by a comparison
against "language_cplus_" value
3) Renaming it to "language_cplus_"

After this point, any instance of "langauge_cplus_" indicates
that we have already examined the situation and it is supposed
to be that way.

The "language_cplus" instances in the comments are not touched
for two reasons:

1) Less amount of changes to avoid likely conflicts in the future
2) When we will go back upstream and have to undo this patch,
there will be a few less things to take care of.