### PR TITLE
Add nightly build workflow for ROCgdb master branch

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,53 @@
+name: Nightly ROCgdb Build
+
+on:
+  schedule:
+    # Run at 2:00 AM UTC every night (avoid :00 and :30 to reduce API load)
+    - cron: '7 2 * * *'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build (default: master)'
+        required: false
+        default: 'master'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-build-linux:
+    name: Nightly Build Linux
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: [gfx94X-dcgpu]
+    uses: ./.github/workflows/therock-ci-linux.yml
+    secrets: inherit
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: nightly-${{ matrix.amdgpu_family }}
+      rocgdb_ref: ${{ inputs.branch || 'master' }}
+      extra_cmake_options: -DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON
+
+  nightly_build_summary:
+    name: Nightly Build Summary
+    if: always()
+    needs:
+      - nightly-build-linux
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,116 @@
+name: Nightly ROCgdb Build
+
+on:
+  schedule:
+    - cron: '7 2 * * *'  # 2:07 AM UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'ROCgdb branch/ref to build (defaults to master)'
+        required: false
+        default: 'master'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-rocgdb-${{ inputs.branch || 'master' }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve TheRock references
+    runs-on: ubuntu-24.04
+    outputs:
+      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
+      build_image: ${{ steps.read.outputs.build_image }}
+      build_runs_on: ${{ steps.runner.outputs.build_runs_on }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read TheRock dependency pins
+        id: read
+        run: python3 .github/scripts/config.py therock_commit_ref build_image
+
+      - name: Select build runner
+        id: runner
+        run: python3 .github/scripts/select_runner.py build_runs_on
+
+  nightly-rocgdb-build-linux:
+    name: Nightly ROCgdb Build Linux
+    needs: resolve
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-ci-linux.yml
+    with:
+      amdgpu_families: dcgpu-all;dgpu-all;igpu-all
+      artifact_group: nightly-rocgdb-multiarch
+      build_runs_on: ${{ needs.resolve.outputs.build_runs_on }}
+      therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      build_image: ${{ needs.resolve.outputs.build_image }}
+      rocgdb_ref: ${{ inputs.branch || 'master' }}
+      extra_cmake_options: >
+        -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
+        -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
+        -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
+        -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
+        -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
+        -DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON
+        -DTHEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON
+
+  test-gpu:
+    name: Test GPU
+    needs: [nightly-rocgdb-build-linux]
+    if: ${{ needs.nightly-rocgdb-build-linux.result == 'success' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: nightly-rocgdb-multiarch
+      therock_ref: ${{ needs.nightly-rocgdb-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+
+  test-cpu:
+    name: Test CPU
+    needs: [nightly-rocgdb-build-linux]
+    if: ${{ needs.nightly-rocgdb-build-linux.result == 'success' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      # CPU tests are gfx-independent; gfx94X selects the artifact set to fetch.
+      amdgpu_families: gfx94X
+      artifact_group: nightly-rocgdb-multiarch
+      therock_ref: ${{ needs.nightly-rocgdb-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-cpu
+
+  nightly_build_summary:
+    name: Nightly Build Summary
+    if: always()
+    needs:
+      - resolve
+      - nightly-rocgdb-build-linux
+      - test-gpu
+      - test-cpu
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,18 @@ on:
         type: string
       extra_cmake_options:
         type: string
+        default: >
+          -DTHEROCK_ENABLE_ALL=OFF
+          -DTHEROCK_BUILD_TESTING=ON
+          -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
+          -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
+          -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
+          -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
+          -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
+      rocgdb_ref:
+        type: string
+        required: false
+        description: 'Branch/ref to checkout for rocGDB (defaults to workflow trigger ref)'
 
 permissions:
   contents: read
@@ -43,6 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: rocgdb_under_test
+          ref: ${{ inputs.rocgdb_ref || github.ref }}
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,10 @@ on:
         type: string
       extra_cmake_options:
         type: string
+      rocgdb_ref:
+        type: string
+        required: false
+        description: 'ROCgdb branch/ref to checkout (defaults to workflow trigger ref)'
       build_runs_on:
         type: string
         default: aws-linux-scale-rocm-prod
@@ -61,6 +65,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: rocgdb_under_test
+          ref: ${{ inputs.rocgdb_ref || github.sha }}
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -51,14 +51,6 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
-        -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
-        -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
-        -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
-        -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
-        -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
 
   therock_ci_summary:
     name: TheRock CI Summary


### PR DESCRIPTION
Adds a scheduled nightly build that tests ROCgdb master against the
current TheRock dependency pins, with GPU, CPU, and corefile test
coverage.

Changes:
- Add nightly-build.yml: runs at 2:07 AM UTC daily; manually
  dispatchable with a configurable ROCgdb branch/ref (defaults to
  master)
- Mirror PR CI build topology: dcgpu-all;dgpu-all;igpu-all with
  multiarch bundle name, runner selected via select_runner.py
- Add concurrency group to prevent overlapping cron/dispatch runs
- Enable upstream builds with THEROCK_ROCGDB_UPSTREAM_BUILD=ON to
  skip AMD-specific files absent on master (NOTICES.txt,
  roccoremerge); add THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON to fetch
  test_rocgdb.py from amd-staging (not present on master)
- Run GPU (gfx94X), CPU (gfx94X, gfx-independent), and corefile
  (gfx942) tests against the nightly artifacts
- Add rocgdb_ref input to therock-ci-linux.yml to allow nightly
  builds to check out a specific ROCgdb branch or ref; fallback
  uses github.sha to preserve PR CI's pinned-SHA checkout semantics
- Echo rocgdb_ref and HEAD commit in build log for traceability

Master nightlies run without rocgdb_ignore_list.json (not fetched
by DOWNLOAD_CI_SCRIPT); known gdb.dwarf2 xfails will appear as
unexpected failures. This is accepted: the nightly is an
informational signal, not a gate.

PR-based CI is unchanged.