### PR TITLE
gdb/amd-dbgapi-target: support attaching without forward progress

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -2584,10 +2584,24 @@ attach_amd_dbgapi (inferior *inf)
       return;
     }
 
+#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR >= 81
+  /* When attaching, commit_resumed_state is expected to be false.  Starting
+     dbgapi-0.81, we can have dbgapi attach with forward progress requirement
+     disabled.  */
+  info.forward_progress_required
+    = info.inf->process_target ()->commit_resumed_state;
+#endif
+
   amd_dbgapi_status_t status
     = amd_dbgapi_process_attach
 	(reinterpret_cast<amd_dbgapi_client_process_id_t> (inf),
-	 &info.process_id);
+	 &info.process_id
+#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR >= 81
+	 , (!info.forward_progress_required
+	    ? AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NO_FORWARD_PROGRESS
+	    : amd_dbgapi_process_attach_flags {})
+#endif
+	 );
   if (status == AMD_DBGAPI_STATUS_ERROR_RESTRICTION)
     {
       warning (_("amd-dbgapi: unable to enable GPU debugging due to a "


### PR DESCRIPTION
An upcoming version of dbgapi will support attaching with forward progress disabled.  This avoid doing multiple queue suspend - resume cycles during the attach when this is not necessary.

To avoid confusing existing clients, this feature is exposed as an opt-in.  This patch teaches GDB about that new interface, and makes sure to attach with forward progress disabled if commit-resumed-state is disabled for the process target.

This patch will be needed for https://github.com/ROCm/rocm-systems/pull/7657

Change-Id: I8b48c2a19a7f089c73cf80820ebacac918a90b65