### PR TITLE
Fix __builtin_verbose_trap support for GPU and CPU

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -2076,14 +2076,18 @@ process_one_event (amd_dbgapi_inferior_info &info,
 	    if (thread == nullptr)
 	      thread = add_gpu_thread (info.inf, event_ptid);
 
-	    /* If the wave is stopped because of a software breakpoint, the
-	       program counter needs to be adjusted so that it points to the
-	       breakpoint instruction.
+	    /* If the wave is stopped because of a software breakpoint or an abort
+	       trap (s_trap 2, used by __builtin_verbose_trap), the program counter
+	       needs to be adjusted so that it points to the trap instruction.
+
+	       For abort traps, this ensures the PC remains in the inlined frame
+	       containing DWARF debug info for verbose trap messages.
 
 	       When dealing with a corefile, it is expected that the PC has
 	       been adjusted before generating the corefile, so no need to
 	       re-do it now.  */
-	    if ((stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT) != 0
+	    if (((stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT) != 0
+		|| (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP) != 0)
 		&& get_inferior_core_bfd (info.inf) == nullptr)
 	      {
 		regcache *regcache = get_thread_regcache (thread);

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -2088,6 +2088,32 @@ amd64_linux_fetch_hiperr_info (frame_info_ptr frame)
   return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGILL occurs.  */
+
+static bool
+amd64_linux_should_show_inline_frame (struct gdbarch *gdbarch,
+				      const struct symbol *func,
+				      enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to illegal instruction.
+     The ud2 instruction used by verbose traps on x86_64 generates SIGILL.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ILL)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static void
 amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
 			     int num_disp_step_buffers)
@@ -2154,6 +2180,11 @@ amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
   /* Extract hiperr info for 'catch hiperr'.  */
   set_gdbarch_fetch_hiperr_info
     (gdbarch, amd64_linux_fetch_hiperr_info);
+
+  /* Show verbose trap inline frames when stopped due to illegal
+     instruction.  */
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amd64_linux_should_show_inline_frame);
 }
 
 static void

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -2088,6 +2088,33 @@ amd64_linux_fetch_hiperr_parameters (frame_info_ptr frame)
   return amd64_fetch_hiperr_parameters (frame, struct_addr);
 }
 
+/* Return true if the inline frame FUNC should be shown when stopped
+   due to STOP_SIGNAL.  This allows showing verbose trap inline frames
+   on x86_64.  */
+
+static bool
+amd64_linux_show_verbose_trap_inline_frame (struct gdbarch *gdbarch,
+					     const struct symbol *func,
+					     enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to illegal instruction.
+     The ud2 instruction used by verbose traps on x86_64 generates SIGILL.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ILL)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static void
 amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
 			     int num_disp_step_buffers)
@@ -2154,6 +2181,10 @@ amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
   /* Extract hiperr parameters for 'catch hiperr'.  */
   set_gdbarch_fetch_hiperr_parameters
     (gdbarch, amd64_linux_fetch_hiperr_parameters);
+
+  /* Show verbose trap inline frames when stopped due to abort.  */
+  set_gdbarch_show_verbose_trap_inline_frame
+    (gdbarch, amd64_linux_show_verbose_trap_inline_frame);
 }
 
 static void

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -2023,6 +2023,31 @@ amdgpu_supports_arch_info (const struct bfd_arch_info *info)
   return status == AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGABRT occurs.  */
+
+static bool
+amdgpu_should_show_inline_frame (struct gdbarch *gdbarch,
+				 const struct symbol *func,
+				 enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to abort signal.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ABRT)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static struct gdbarch *
 amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 {
@@ -2274,6 +2299,9 @@ amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
     error (_("amd_dbgapi_architecture_get_info failed"));
 
   set_gdbarch_decr_pc_after_break (gdbarch, pc_adjust);
+
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amdgpu_should_show_inline_frame);
 
   /* Get info about address spaces.  */
   size_t address_space_count;

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -2019,6 +2019,30 @@ amdgpu_supports_arch_info (const struct bfd_arch_info *info)
   return status == AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+/* Implementation of gdbarch_show_verbose_trap_inline_frame for AMDGPU.  */
+
+static bool
+amdgpu_show_verbose_trap_inline_frame (struct gdbarch *gdbarch,
+				       const struct symbol *func,
+				       enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to abort signal.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ABRT)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static struct gdbarch *
 amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 {
@@ -2270,6 +2294,9 @@ amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
     error (_("amd_dbgapi_architecture_get_info failed"));
 
   set_gdbarch_decr_pc_after_break (gdbarch, pc_adjust);
+
+  set_gdbarch_show_verbose_trap_inline_frame
+    (gdbarch, amdgpu_show_verbose_trap_inline_frame);
 
   /* Get info about address spaces.  */
   size_t address_space_count;

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1613,6 +1613,18 @@ core_file_exec_context::environment () const
   return e;
 }
 
+/* See arch-utils.h.  */
+
+/* Default implementation: don't show inline frames.  */
+
+bool
+default_should_show_inline_frame (struct gdbarch *gdbarch,
+				  const struct symbol *func,
+				  enum gdb_signal stop_signal)
+{
+  return false;
+}
+
 INIT_GDB_FILE (gdbarch_utils)
 {
   add_setshow_enum_cmd ("endian", class_support,

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1613,6 +1613,17 @@ core_file_exec_context::environment () const
   return e;
 }
 
+/* See arch-utils.h.  */
+
+bool
+default_show_verbose_trap_inline_frame (struct gdbarch *gdbarch,
+					const struct symbol *func,
+					enum gdb_signal stop_signal)
+{
+  /* By default, do not show verbose trap inline frames.  */
+  return false;
+}
+
 INIT_GDB_FILE (gdbarch_utils)
 {
   add_setshow_enum_cmd ("endian", class_support,

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -451,4 +451,9 @@ extern int default_supported_lanes_count (struct gdbarch *gdbarch,
 extern std::vector<addr_range> default_get_watchable_aliases
   (struct gdbarch *gdbarch, ptid_t ptid, int simd_lane, addr_range range);
 
+/* Default implementation of gdbarch_should_show_inline_frame.  */
+extern bool default_should_show_inline_frame
+  (struct gdbarch *gdbarch, const struct symbol *func,
+   enum gdb_signal stop_signal);
+
 #endif /* GDB_ARCH_UTILS_H */

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -451,4 +451,9 @@ extern int default_supported_lanes_count (struct gdbarch *gdbarch,
 extern std::vector<addr_range> default_get_watchable_aliases
   (struct gdbarch *gdbarch, ptid_t ptid, int simd_lane, addr_range range);
 
+/* Default implementation of gdbarch_show_verbose_trap_inline_frame.  */
+extern bool default_show_verbose_trap_inline_frame
+  (struct gdbarch *gdbarch, const struct symbol *func,
+   enum gdb_signal stop_signal);
+
 #endif /* GDB_ARCH_UTILS_H */

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -265,6 +265,7 @@ struct gdbarch
   gdbarch_core_parse_exec_context_ftype *core_parse_exec_context = default_core_parse_exec_context;
   gdbarch_shadow_stack_push_ftype *shadow_stack_push = nullptr;
   gdbarch_get_shadow_stack_pointer_ftype *get_shadow_stack_pointer = default_get_shadow_stack_pointer;
+  gdbarch_show_verbose_trap_inline_frame_ftype *show_verbose_trap_inline_frame = default_show_verbose_trap_inline_frame;
 };
 
 /* Create a new ``struct gdbarch'' based on information provided by
@@ -547,6 +548,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of core_parse_exec_context, invalid_p == 0.  */
   /* Skip verify of shadow_stack_push, has predicate.  */
   /* Skip verify of get_shadow_stack_pointer, invalid_p == 0.  */
+  /* Skip verify of show_verbose_trap_inline_frame, invalid_p == 0.  */
   if (!log.empty ())
     internal_error (_("verify_gdbarch: the following are invalid ...%s"),
 		    log.c_str ());
@@ -1421,6 +1423,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: get_shadow_stack_pointer = <%s>\n",
 	      host_address_to_string (gdbarch->get_shadow_stack_pointer));
+  gdb_printf (file,
+	      "gdbarch_dump: show_verbose_trap_inline_frame = <%s>\n",
+	      host_address_to_string (gdbarch->show_verbose_trap_inline_frame));
   if (gdbarch->dump_tdep != nullptr)
     gdbarch->dump_tdep (gdbarch, file);
 }
@@ -5599,4 +5604,21 @@ set_gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch,
 				      gdbarch_get_shadow_stack_pointer_ftype get_shadow_stack_pointer)
 {
   gdbarch->get_shadow_stack_pointer = get_shadow_stack_pointer;
+}
+
+bool
+gdbarch_show_verbose_trap_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal)
+{
+  gdb_assert (gdbarch != nullptr);
+  gdb_assert (gdbarch->show_verbose_trap_inline_frame != nullptr);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_show_verbose_trap_inline_frame called\n");
+  return gdbarch->show_verbose_trap_inline_frame (gdbarch, func, stop_signal);
+}
+
+void
+set_gdbarch_show_verbose_trap_inline_frame (struct gdbarch *gdbarch,
+					    gdbarch_show_verbose_trap_inline_frame_ftype show_verbose_trap_inline_frame)
+{
+  gdbarch->show_verbose_trap_inline_frame = show_verbose_trap_inline_frame;
 }

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -265,6 +265,7 @@ struct gdbarch
   gdbarch_core_parse_exec_context_ftype *core_parse_exec_context = default_core_parse_exec_context;
   gdbarch_shadow_stack_push_ftype *shadow_stack_push = nullptr;
   gdbarch_get_shadow_stack_pointer_ftype *get_shadow_stack_pointer = default_get_shadow_stack_pointer;
+  gdbarch_should_show_inline_frame_ftype *should_show_inline_frame = default_should_show_inline_frame;
 };
 
 /* Create a new ``struct gdbarch'' based on information provided by
@@ -547,6 +548,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of core_parse_exec_context, invalid_p == 0.  */
   /* Skip verify of shadow_stack_push, has predicate.  */
   /* Skip verify of get_shadow_stack_pointer, invalid_p == 0.  */
+  /* Skip verify of should_show_inline_frame, invalid_p == 0.  */
   if (!log.empty ())
     internal_error (_("verify_gdbarch: the following are invalid ...%s"),
 		    log.c_str ());
@@ -1421,6 +1423,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: get_shadow_stack_pointer = <%s>\n",
 	      host_address_to_string (gdbarch->get_shadow_stack_pointer));
+  gdb_printf (file,
+	      "gdbarch_dump: should_show_inline_frame = <%s>\n",
+	      host_address_to_string (gdbarch->should_show_inline_frame));
   if (gdbarch->dump_tdep != nullptr)
     gdbarch->dump_tdep (gdbarch, file);
 }
@@ -5599,4 +5604,21 @@ set_gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch,
 				      gdbarch_get_shadow_stack_pointer_ftype get_shadow_stack_pointer)
 {
   gdbarch->get_shadow_stack_pointer = get_shadow_stack_pointer;
+}
+
+bool
+gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal)
+{
+  gdb_assert (gdbarch != nullptr);
+  gdb_assert (gdbarch->should_show_inline_frame != nullptr);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_should_show_inline_frame called\n");
+  return gdbarch->should_show_inline_frame (gdbarch, func, stop_signal);
+}
+
+void
+set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch,
+				      gdbarch_should_show_inline_frame_ftype should_show_inline_frame)
+{
+  gdbarch->should_show_inline_frame = should_show_inline_frame;
 }

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1858,3 +1858,25 @@ void set_gdbarch_shadow_stack_push (struct gdbarch *gdbarch, gdbarch_shadow_stac
 using gdbarch_get_shadow_stack_pointer_ftype = std::optional<CORE_ADDR> (struct gdbarch *gdbarch, regcache *regcache, bool &shadow_stack_enabled);
 std::optional<CORE_ADDR> gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch, regcache *regcache, bool &shadow_stack_enabled);
 void set_gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch, gdbarch_get_shadow_stack_pointer_ftype *get_shadow_stack_pointer);
+
+/* Determine whether an inline frame should be shown in backtraces.
+
+   This hook is called when GDB encounters an inline frame to decide whether
+   it should be displayed to the user or hidden.  By default, inline frames
+   are hidden during normal stepping to provide a source-level debugging
+   experience.  However, some inline frames contain important diagnostic
+   information that should always be visible.
+
+   A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+   which embed crash diagnostic messages in specially-named inline frames.
+   When such a trap fires, the inline frame should be shown even though
+   inline frames are normally hidden.
+
+   The hook receives the inline frame's symbol and the signal that stopped
+   execution, allowing architecture-specific code to make the decision.
+
+   Return true if the inline frame should be shown, false to hide it. */
+
+using gdbarch_should_show_inline_frame_ftype = bool (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+bool gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+void set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, gdbarch_should_show_inline_frame_ftype *should_show_inline_frame);

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1852,3 +1852,21 @@ void set_gdbarch_shadow_stack_push (struct gdbarch *gdbarch, gdbarch_shadow_stac
 using gdbarch_get_shadow_stack_pointer_ftype = std::optional<CORE_ADDR> (struct gdbarch *gdbarch, regcache *regcache, bool &shadow_stack_enabled);
 std::optional<CORE_ADDR> gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch, regcache *regcache, bool &shadow_stack_enabled);
 void set_gdbarch_get_shadow_stack_pointer (struct gdbarch *gdbarch, gdbarch_get_shadow_stack_pointer_ftype *get_shadow_stack_pointer);
+
+/* Return true if the inline frame represented by FUNC should NOT be skipped
+   when stopped due to STOP_SIGNAL.  This allows architectures to show
+   compiler-generated inline frames that contain verbose trap messages
+   (e.g., __builtin_verbose_trap).
+
+   By default, inline frames are skipped to provide better stepping experience.
+   However, for verbose trap scenarios, the inline frame contains important
+   diagnostic information that should be visible in backtraces.
+
+   Architectures can use this hook to detect verbose trap frames by checking
+   both the symbol name (e.g., starts with "__clang_trap_msg$") and the stop
+   signal (e.g., GDB_SIGNAL_ABRT for abort traps), returning true only when
+   both conditions indicate a verbose trap scenario. */
+
+using gdbarch_show_verbose_trap_inline_frame_ftype = bool (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+bool gdbarch_show_verbose_trap_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+void set_gdbarch_show_verbose_trap_inline_frame (struct gdbarch *gdbarch, gdbarch_show_verbose_trap_inline_frame_ftype *show_verbose_trap_inline_frame);

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2952,3 +2952,30 @@ SHADOW_STACK_ENABLED to false.
     predefault="default_get_shadow_stack_pointer",
     invalid=False,
 )
+
+Method(
+    comment="""
+Determine whether an inline frame should be shown in backtraces.
+
+This hook is called when GDB encounters an inline frame to decide whether
+it should be displayed to the user or hidden.  By default, inline frames
+are hidden during normal stepping to provide a source-level debugging
+experience.  However, some inline frames contain important diagnostic
+information that should always be visible.
+
+A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+which embed crash diagnostic messages in specially-named inline frames.
+When such a trap fires, the inline frame should be shown even though
+inline frames are normally hidden.
+
+The hook receives the inline frame's symbol and the signal that stopped
+execution, allowing architecture-specific code to make the decision.
+
+Return true if the inline frame should be shown, false to hide it.
+""",
+    type="bool",
+    name="should_show_inline_frame",
+    params=[("const struct symbol *", "func"), ("enum gdb_signal", "stop_signal")],
+    predefault="default_should_show_inline_frame",
+    invalid=False,
+)

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2944,3 +2944,26 @@ SHADOW_STACK_ENABLED to false.
     predefault="default_get_shadow_stack_pointer",
     invalid=False,
 )
+
+Method(
+    comment="""
+Return true if the inline frame represented by FUNC should NOT be skipped
+when stopped due to STOP_SIGNAL.  This allows architectures to show
+compiler-generated inline frames that contain verbose trap messages
+(e.g., __builtin_verbose_trap).
+
+By default, inline frames are skipped to provide better stepping experience.
+However, for verbose trap scenarios, the inline frame contains important
+diagnostic information that should be visible in backtraces.
+
+Architectures can use this hook to detect verbose trap frames by checking
+both the symbol name (e.g., starts with "__clang_trap_msg$") and the stop
+signal (e.g., GDB_SIGNAL_ABRT for abort traps), returning true only when
+both conditions indicate a verbose trap scenario.
+""",
+    type="bool",
+    name="show_verbose_trap_inline_frame",
+    params=[("const struct symbol *", "func"), ("enum gdb_signal", "stop_signal")],
+    predefault="default_show_verbose_trap_inline_frame",
+    invalid=False,
+)

--- a/gdb/inline-frame.c
+++ b/gdb/inline-frame.c
@@ -28,6 +28,7 @@
 #include "regcache.h"
 #include "symtab.h"
 #include "frame.h"
+#include "gdbarch.h"
 #include "cli/cli-cmds.h"
 #include "cli/cli-style.h"
 #include <algorithm>
@@ -428,10 +429,14 @@ skip_inline_frames (thread_info *thread, bpstat *stop_chain)
      which contains all of the inlined functions, we never skip this.  */
   int skipped_frames = 0;
 
+  struct gdbarch *gdbarch = get_frame_arch (get_current_frame ());
+  enum gdb_signal stop_signal = thread->stop_signal ();
+
   for (const auto sym : function_symbols)
     {
       if (stopped_by_user_bp_inline_frame (sym, stop_chain)
-	  || sym == function_symbols.back ())
+	  || sym == function_symbols.back ()
+	  || gdbarch_show_verbose_trap_inline_frame (gdbarch, sym, stop_signal))
 	break;
 
       ++skipped_frames;

--- a/gdb/inline-frame.c
+++ b/gdb/inline-frame.c
@@ -28,6 +28,7 @@
 #include "regcache.h"
 #include "symtab.h"
 #include "frame.h"
+#include "gdbarch.h"
 #include "cli/cli-cmds.h"
 #include "cli/cli-style.h"
 #include <algorithm>
@@ -428,10 +429,14 @@ skip_inline_frames (thread_info *thread, bpstat *stop_chain)
      which contains all of the inlined functions, we never skip this.  */
   int skipped_frames = 0;
 
+  struct gdbarch *gdbarch = get_frame_arch (get_current_frame ());
+  enum gdb_signal stop_signal = thread->stop_signal ();
+
   for (const auto sym : function_symbols)
     {
       if (stopped_by_user_bp_inline_frame (sym, stop_chain)
-	  || sym == function_symbols.back ())
+	  || sym == function_symbols.back ()
+	  || gdbarch_should_show_inline_frame (gdbarch, sym, stop_signal))
 	break;
 
       ++skipped_frames;

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
@@ -1,0 +1,38 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* Regular inline function - inline frame should be skipped during stepping.  */
+__attribute__((always_inline)) inline int
+add_numbers (int a, int b)
+{
+  return a + b;
+}
+
+void
+test_trap_function ()
+{
+  int x = 1;  /* Breakpoint here.  */
+  int y = 2;
+  int z = add_numbers (x, y);  /* Step over inline function.  */
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_function ();
+  return 0;
+}

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+void
+test_trap_function ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_function ();
+  return 0;
+}

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap inline frames are shown when trap fires.
+# __builtin_verbose_trap is a Clang-only builtin, added in Clang 19.
+
+require {expr {[test_compiler_info clang*]
+	       && ![test_compiler_info {clang-1[0-8]-*}]
+	       && ![test_compiler_info {clang-[1-9]-*}]}}
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction with the
+# previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug c++}]} {
+    return
+}
+
+if {![runto test_trap_function]} {
+    return
+}
+
+# Continue to trigger the trap.
+gdb_test "continue" \
+    "received signal SIGILL.*" \
+    "received trap signal"
+
+# Verify verbose trap message appears in backtrace.
+gdb_test "bt" \
+    "This is verbose trap.*" \
+    "verbose trap message appears in backtrace"
+
+# Test single stepping to the trap line.
+# Expected: step should stop at __builtin_verbose_trap line, then
+# next step triggers the trap.
+clean_restart $testfile
+
+if {![runto_main]} {
+    return
+}
+
+# Set breakpoint at "int x = 1" line to avoid line table ambiguity
+# when running to the test function.
+set line_x [gdb_get_line_number "int x = 1"]
+gdb_breakpoint "$srcfile:$line_x"
+gdb_test "continue" "Breakpoint.*$line_x.*" "run to line $line_x"
+
+# Check for compiler line table bug using info line.
+# If the __builtin_verbose_trap line shows "contains no code",
+# the trap instruction is not mapped to that line (bug exists).
+set has_line_table_bug 0
+set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+gdb_test_multiple "info line $line_trap" "" {
+    -re "contains no code" {
+	set has_line_table_bug 1
+	exp_continue
+    }
+    -re -wrap "" {
+	pass $gdb_test_name
+    }
+}
+
+gdb_test_multiple "next" "step to trap line" {
+    -re -wrap "SIGILL.*" {
+	if {$has_line_table_bug} {
+	    xfail "$gdb_test_name (compiler line table bug)"
+	} else {
+	    fail "$gdb_test_name"
+	}
+    }
+    -re -wrap "__builtin_verbose_trap.*" {
+	pass $gdb_test_name
+
+	# Next step should trigger the trap.
+	gdb_test "next" "SIGILL.*" "step triggers trap"
+    }
+}

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap inline frames are shown when trap fires.
+# __builtin_verbose_trap is a Clang-only builtin, added in Clang 17.
+
+require {expr {[test_compiler_info clang*] && ![test_compiler_info {clang-1[0-6]-*}]}}
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug c++}]} {
+    return
+}
+
+if {![runto_main]} {
+    return
+}
+
+# Set breakpoint in function before inline function call.
+gdb_breakpoint "test_trap_function"
+
+# Continue to breakpoint.
+gdb_test "continue" \
+    ".*Breakpoint.*test_trap_function.*" \
+    "hit breakpoint in function"
+
+# Step through inline function calls with next.
+# The inline frames for add_numbers should be hidden.
+gdb_test "next" ".*" "next 1"
+gdb_test "next" ".*" "next 2"
+
+# Verify backtrace does NOT show add_numbers inline frame.
+gdb_test "bt" \
+    ".*test_trap_function.*" \
+    "inline frame not shown during stepping"
+
+gdb_test_no_output "set confirm off"
+
+# Continue to trigger the trap.
+# CPU uses ud2 instruction which generates SIGILL (not SIGABRT like GPU).
+gdb_test "continue" \
+    ".*received signal SIGILL.*" \
+    "received trap signal"
+
+# Verify verbose trap message appears in backtrace.
+gdb_test "bt" \
+    ".*This is verbose trap.*" \
+    "verbose trap message appears in backtrace"

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <hip/hip_runtime.h>
+
+__global__ void
+test_trap_kernel ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_kernel<<<1, 1>>> ();
+  return hipDeviceSynchronize () != hipSuccess;
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
@@ -1,0 +1,44 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <hip/hip_runtime.h>
+
+/* Regular inline function - inline frame should be skipped during stepping.  */
+__device__ __attribute__((always_inline)) inline int
+add_numbers (int a, int b)
+{
+  return a + b;
+}
+
+__global__ void
+test_trap_kernel ()
+{
+  int x = 1;  /* Breakpoint here.  */
+  int y = 2;
+  int z = add_numbers (x, y);  /* Step into inline function.  */
+  int r = add_numbers (x, y);
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_kernel<<<1, 1>>> ();
+  return hipDeviceSynchronize () != hipSuccess;
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
@@ -31,8 +31,7 @@ test_trap_kernel ()
 {
   int x = 1;  /* Breakpoint here.  */
   int y = 2;
-  int z = add_numbers (x, y);  /* Step into inline function.  */
-  int r = add_numbers (x, y);
+  int z = add_numbers (x, y);  /* Step over inline function.  */
   __builtin_verbose_trap ("check verbose", "This is verbose trap!");
 }
 

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap PC is correctly adjusted.
+
+load_lib rocm.exp
+require allow_hip_tests
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction
+# with the previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+with_rocm_gpu_lock {
+    if {![runto test_trap_kernel -allow-pending]} {
+	return
+    }
+
+    # Continue to trigger the trap.
+    gdb_test "continue" \
+	"received signal SIGABRT.*" \
+	"received trap signal"
+
+    # Check PC points to trap instruction.
+    gdb_test "x/i \$pc" \
+	"s_trap.*" \
+	"PC points to trap instruction"
+
+    # Verify verbose trap message appears in backtrace.
+    gdb_test "bt" \
+	"This is verbose trap.*" \
+	"verbose trap message appears in backtrace"
+
+    # Test single stepping to the trap line.
+    # Expected: step should stop at __builtin_verbose_trap line, then
+    # next step triggers the trap.
+    clean_restart $testfile
+
+    if {![runto test_trap_kernel -allow-pending]} {
+	return
+    }
+
+    # Check for compiler line table bug using info line.
+    # If the __builtin_verbose_trap line shows "contains no code",
+    # the trap instruction is not mapped to that line (bug exists).
+    set has_line_table_bug 0
+    set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+    gdb_test_multiple "info line $line_trap" "" {
+	-re "contains no code" {
+	    set has_line_table_bug 1
+	    exp_continue
+	}
+	-re -wrap "" {
+	    pass $gdb_test_name
+	}
+    }
+
+    gdb_test_multiple "next" "step to trap line" {
+	-re -wrap "SIGABRT.*" {
+	    if {$has_line_table_bug} {
+		xfail "$gdb_test_name (compiler line table bug)"
+	    } else {
+		fail "$gdb_test_name"
+	    }
+	}
+	-re -wrap "__builtin_verbose_trap.*" {
+	    pass $gdb_test_name
+
+	    # Next step should trigger the trap.
+	    gdb_test "next" "SIGABRT.*" "step triggers trap"
+	}
+    }
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
@@ -45,7 +45,6 @@ with_rocm_gpu_lock {
     # The inline frames for add_numbers should be hidden.
     gdb_test "next" ".*" "next 1"
     gdb_test "next" ".*" "next 2"
-    gdb_test "next" ".*" "next 3"
 
     # Verify backtrace does NOT show add_numbers inline frame.
     gdb_test "bt" \

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
@@ -1,0 +1,72 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap PC is correctly adjusted.
+
+load_lib rocm.exp
+require allow_hip_tests
+standard_testfile .cpp
+
+if {[build_executable "failed to build" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+clean_restart $::testfile
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    # Set breakpoint in kernel before inline function call.
+    gdb_breakpoint "test_trap_kernel" -allow-pending
+
+    # Continue to breakpoint.
+    gdb_test "continue" \
+	".*Breakpoint.*test_trap_kernel.*" \
+	"hit breakpoint in kernel"
+
+    # Step through inline function calls with next.
+    # The inline frames for add_numbers should be hidden.
+    gdb_test "next" ".*" "next 1"
+    gdb_test "next" ".*" "next 2"
+    gdb_test "next" ".*" "next 3"
+
+    # Verify backtrace does NOT show add_numbers inline frame.
+    gdb_test "bt" \
+	".*test_trap_kernel.*" \
+	"inline frame not shown during stepping"
+
+    gdb_test_no_output "set confirm off"
+
+    # Continue to trigger the trap.
+    gdb_test "continue" \
+	".*received signal SIGABRT.*" \
+	"received trap signal"
+
+    # Check PC points to trap instruction.
+    # If PC adjustment is working, PC should be at the s_trap instruction.
+    gdb_test "x/i \$pc" \
+	".*s_trap.*" \
+	"PC points to trap instruction"
+
+    # Verify verbose trap message appears in backtrace.
+    gdb_test "bt" \
+	".*This is verbose trap.*" \
+	"verbose trap message appears in backtrace"
+}


### PR DESCRIPTION
Ticket: AIROCGDB-558


### Summary
Implements complete support for `__builtin_verbose_trap` on both AMD GPU and CPU (x86_64), making verbose trap diagnostic messages visible in backtraces.

### Problem
When `__builtin_verbose_trap` fired, the diagnostic inline frames were not visible in backtraces, making it impossible to see the trap category and message. Two issues prevented this:

1. **PC pointing past trap instruction**: After s_trap 2 on GPU, PC was not rewound to point at the trap instruction, causing GDB to miss the inlined DWARF frame containing the diagnostic info
2. **Inline frames hidden by default**: GDB's `skip_inline_frames()` intentionally hides inline frames to improve stepping experience, but this also hid the verbose trap frames

### Solution

This PR provides a two-part fix:

#### 1. PC Adjustment for s_trap 2 (GPU)
Rewind PC by 4 bytes when a wave stops with s_trap 2, similar to breakpoint handling. This ensures the PC remains in the inlined DWARF frame containing `__builtin_verbose_trap` debug info.

**Files changed:**
- `gdb/amd-dbgapi-target.c` - PC adjustment logic
- `gdb/testsuite/gdb.rocm/builtin_verbose_trap.{cpp,exp}` - Test coverage

#### 2. gdbarch Hook for Inline Frame Control (GPU + CPU)
Adds architecture-specific control over inline frame visibility using GDB's gdbarch pattern. Architectures can now prevent skipping of compiler-generated inline frames containing diagnostic information.

**Changes:**
- `gdb/gdbarch_components.py` - Define `show_verbose_trap_inline_frame` method
- `gdb/arch-utils.{c,h}` - Default implementation (preserves current behavior)
- `gdb/amdgpu-tdep.c` - AMD GPU implementation (checks `SIGABRT` + name pattern)
- `gdb/amd64-linux-tdep.c` - CPU x86_64 implementation (checks `SIGILL` + name pattern)
- `gdb/inline-frame.c` - Call gdbarch hook in skip loop
- `gdb/gdbarch-gen.{c,h}` - Auto-generated

**Detection logic:**
- Only shows frame when **both** conditions met:
  1. Stop signal matches trap type (`SIGABRT` for GPU s_trap 2, `SIGILL` for CPU ud2)
  2. Symbol name starts with `__clang_trap_msg$<category>$<message>`
- Preserves normal stepping behavior (frames hidden when user steps into them)

### Results

**Before:**
```
Thread 6 received signal SIGABRT, Aborted.
#0  test_trap_kernel () at test.cpp:24
```

**After (GPU):**
```
Thread 6 received signal SIGABRT, Aborted.
#0  __clang_trap_msg$check verbose$This is verbose trap! ()
    at test.cpp:23
#1  test_trap_kernel () at test.cpp:24
```

**After (CPU):**
```
Program received signal SIGILL, Illegal instruction.
#0  __clang_trap_msg$check negative$Value must be non-negative! ()
    at test.cpp:4
#1  check_value (value=-1) at test.cpp:5
#2  main () at test.cpp:12
```