### PR TITLE
fix to enable new wave creation for MI200.

### DIFF
--- a/gdb/testsuite/gdb.rocm/hog.cpp
+++ b/gdb/testsuite/gdb.rocm/hog.cpp
@@ -47,11 +47,58 @@ main ()
   hipDeviceProp_t props;
   CHECK (hipGetDeviceProperties (&props, deviceId));
 
-  /* We use a single workgroup with as many workitems as the
-     architecture allows which guarantees that when hog terminates
-     resources are released allowing the hw to schedule new waves
-     into vacated slots. */
-  hog_kernel<<<1, props.maxThreadsPerBlock>>> ();
+  /* Heuristics to scale the `hog` kernel for occupying a significant portion
+     of the GPU's concurrent wave execution capacity, regardless of GPU size.
+
+     Target: ~432 total waves (works well on 36 CU GPU:
+     at least 12 waves per CU: 36 x 12 = 432)
+     - Small GPUs (<= 8 CUs): scale #_of_CUs by some factor to ensure saturation
+       the factor is ad hoc 50 as 8 x 50 = 400 close to target
+     - Medium/Large GPUs: Use 432 waves or 12×CU count, whichever is larger
+
+     This ensures:
+     1. Small GPUs get enough waves to create resource pressure
+     2. Large GPUs don't launch excessively many waves
+     3. Total wave count is predictable and reasonable
+  */
+
+  const size_t threads_per_wave = props.warpSize; // either 32 or 64
+  constexpr size_t THREADS_PER_BLOCK = 256;
+  constexpr size_t TINY_GPU_CU_COUNT = 8;
+  constexpr size_t BIG_GPU_CU_COUNT = 36;
+  constexpr size_t WAVES_PER_CU_4_TINY = 50;
+  constexpr size_t MAX_WAVES_PER_CU = 12;
+  constexpr size_t TARGET_WAVES = BIG_GPU_CU_COUNT * MAX_WAVES_PER_CU; // i.e. 432
+  constexpr size_t MIN_TARGET_WAVES = 100;
+  constexpr size_t MAX_TARGET_WAVES = 5000;
+
+  /* Calculate target waves */
+  size_t target_waves;
+  const char *env_waves_total = getenv ("HOG_TOTAL_WAVES");
+  size_t cu_count = props.multiProcessorCount;
+
+  if (env_waves_total != nullptr)
+    target_waves = atoi (env_waves_total);
+  else
+    {
+      target_waves = (cu_count > TINY_GPU_CU_COUNT)
+      ? std::max (TARGET_WAVES, cu_count * MAX_WAVES_PER_CU)
+      : cu_count * WAVES_PER_CU_4_TINY;
+    }
+
+  target_waves = std::clamp (target_waves, MIN_TARGET_WAVES, MAX_TARGET_WAVES);
+
+  size_t blocks = (target_waves * threads_per_wave + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+  size_t waves_per_cu = target_waves / cu_count;
+
+  // Diagnostic output
+  fprintf(stderr, "Hog: GPU '%s' with %zu CUs, wave size %zu\n",
+    props.name, cu_count, threads_per_wave);
+  fprintf(stderr, " Launching %zu blocks x %zu threads = %zu waves "
+    "(~%zu waves/CU)\n", blocks, THREADS_PER_BLOCK, target_waves, waves_per_cu);
+
+  hog_kernel<<<blocks, THREADS_PER_BLOCK>>> ();
+
   CHECK (hipDeviceSynchronize ());
   return 0;
 }


### PR DESCRIPTION
## Motivation

`step-schedlock-spurious-waves.exp` fails on MI200 for new waves creation subtest.

## Technical Details

Scale the hog kernel to occupy a significant portion of the GPU's
concurrent wave execution capacity, regardless of GPU size.

## Test Plan

Run gdb.rocm step-schedlock-spurious-waves.exp on MI200.

## Test Result

The step-schedlock-spurious-waves.exp should pass completely on MI200.

