### PR TITLE
Implements the "maintenance info amdgpu address-aliases" command

### DIFF
--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -7,6 +7,11 @@ Full documentation for ROCgdb is available at
 
 ### Added
 
+- The "maint info amdgpu address-aliases" command evaluate a given
+  expression to an address, and show what the address aliases to in
+  every address space known to the current AMD GPU selected
+  architecture.
+
 - Improve "maint print address-spaces" command to display properties
   of address spaces supported by an architecture.  For each address
   space, print its name, DWARF id, address size, null address, and

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -35,6 +35,8 @@
 #include "reggroups.h"
 #include "extract-store-integer.h"
 #include <optional>
+#include "cli/cli-cmds.h"
+#include "cli/cli-style.h"
 
 struct amdgpu_per_inferior
 {
@@ -93,6 +95,9 @@ amdgpu_get_segment_address_significant_bits (inferior *inf)
 
   return *per_inf.significant_bits;
 }
+
+/* List of maint info amdgpu commands.  */
+static struct cmd_list_element *maintenance_info_amdgpu_list;
 
 /* Return true if INFO is of an AMDGPU architecture.  */
 
@@ -1930,6 +1935,143 @@ amdgpu_get_watchable_aliases (struct gdbarch *gdbarch,
   return aliases;
 }
 
+/* Show for each address space supported by the current AMDGPU
+   architecture the aliases of a given ADDR, and the number of
+   consecutive bytes for which each aliasing is valid.
+
+   This is purely a diagnostic aid: it queries
+   amd_dbgapi_convert_address_space for every address space known to
+   the architecture and reports "<not reachable>" for the ones the
+   given address does not alias into.  */
+
+static void
+amdgpu_info_address_aliases_command (const char *exp, int from_tty)
+{
+  /* A series of sanity checks.  */
+  if (exp == nullptr || *exp == '\0')
+    error (_("Argument required."));
+
+  expression_up expr = parse_expression (exp);
+  struct gdbarch *gdbarch = expr->gdbarch;
+  if (!is_amdgpu_arch (gdbarch))
+    error (_("Current architecture is not AMDGPU."));
+
+  if (inferior_ptid == null_ptid)
+    error (_("No thread selected."));
+
+  if (!ptid_is_gpu (inferior_ptid))
+    error (_("Current thread is not an AMDGPU GPU thread."));
+
+  struct value *val = expr->evaluate ();
+  if (TYPE_IS_REFERENCE (val->type ()))
+    val = coerce_ref (val);
+  CORE_ADDR addr = value_as_address (val);
+
+  amd_dbgapi_architecture_id_t architecture_id;
+  amd_dbgapi_status_t status = amd_dbgapi_get_architecture
+    (gdbarch_bfd_arch_info (gdbarch)->mach, &architecture_id);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    error (_("amd_dbgapi_get_architecture failed (%s)"),
+	   get_status_string (status));
+
+  arch_addr_space_id src_aspace_num
+    = amdgpu_address_space_id_from_core_address (addr);
+
+  amd_dbgapi_address_space_id_t src_aspace;
+  status = amd_dbgapi_dwarf_address_space_to_address_space (architecture_id,
+							    src_aspace_num,
+							    &src_aspace);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    error (_("amd_dbgapi_dwarf_address_space_to_address_space failed (%s)"),
+	   get_status_string (status));
+
+  CORE_ADDR offset = amdgpu_segment_address_from_core_address (addr);
+
+  /* amd_dbgapi_convert_address_space special-cases the NULL segment
+     address of the source space: it succeeds and returns the NULL
+     segment address of the destination space, without this being a
+     genuine alias.  Detect that case up front so it isn't reported
+     as a real hit below.  */
+  amd_dbgapi_segment_address_t src_null_address;
+  status = amd_dbgapi_address_space_get_info
+    (src_aspace, AMD_DBGAPI_ADDRESS_SPACE_INFO_NULL_ADDRESS,
+     sizeof (src_null_address), &src_null_address);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    error (_("amd_dbgapi_address_space_get_info (NULL_ADDRESS) failed (%s)"),
+	   get_status_string (status));
+  bool src_is_null_address = (offset == src_null_address);
+
+  const amd_dbgapi_wave_id_t wave_id
+    = get_amd_dbgapi_wave_id (inferior_thread ()->ptid);
+  const amd_dbgapi_lane_id_t lane_id
+    = inferior_thread ()->current_simd_lane ();
+  const gdb::array_view<const arch_addr_space> aspaces
+    = amdgpu_address_spaces (gdbarch);
+
+  /* First pass: size the "Address space" column to the longest name.
+     Initialize with the header title width so the column is never
+     narrower than the label.  */
+  size_t max_aspace_name_len = strlen (_("Address space"));
+  for (const auto &address_space : aspaces)
+    max_aspace_name_len = std::max (max_aspace_name_len,
+				    strlen (address_space.name.get ()));
+
+  int addr_width = 4 + (gdbarch_ptr_bit (gdbarch) / 4);
+
+  struct ui_out *ui_out = current_uiout;
+  ui_out_emit_table table_emitter (ui_out, 3, aspaces.size (), "aliases");
+
+  ui_out->table_header (max_aspace_name_len, ui_left, "aspace",
+			_("Address space"));
+  /* Address form is: <name>#0xNN..NNN for a named space,
+     or just 0xNN..NNN for the default (global) space.  */
+  ui_out->table_header (max_aspace_name_len + addr_width,
+			ui_right, "addr", _("Address"));
+  ui_out->table_header (addr_width, ui_right, "valid", _("Valid for"));
+  ui_out->table_body ();
+
+  for (const auto &address_space : aspaces)
+    {
+      amd_dbgapi_address_space_id_t dst_aspace;
+      status = amd_dbgapi_dwarf_address_space_to_address_space
+	(architecture_id, address_space.id, &dst_aspace);
+      if (status != AMD_DBGAPI_STATUS_SUCCESS)
+	error (_("amd_dbgapi_dwarf_address_space_to_address_space failed (%s)"),
+	       get_status_string (status));
+
+      ui_out_emit_tuple tuple_emitter (ui_out, "alias");
+
+      amd_dbgapi_segment_address_t dst_offset;
+      amd_dbgapi_size_t cont_bytes;
+      status = amd_dbgapi_convert_address_space (wave_id, lane_id, src_aspace,
+						 offset, dst_aspace,
+						 &dst_offset, &cont_bytes);
+      ui_out->field_string ("aspace", address_space.name.get ());
+      if (status != AMD_DBGAPI_STATUS_SUCCESS)
+	{
+	  ui_out->field_string ("addr", "<not reachable>");
+	  ui_out->field_string ("valid", "0x0");
+	}
+      else
+	{
+	  CORE_ADDR dst_address
+	    = amdgpu_segment_address_to_core_address (address_space.id,
+						      dst_offset);
+	  ui_out->field_string ("addr", paspace_and_addr (gdbarch,
+							  dst_address),
+				address_style.style ());
+
+	  /* Not a real alias, NULL just maps to NULL in every
+	     space.  */
+	  if (src_is_null_address)
+	    ui_out->field_string ("valid", "<null>");
+	  else
+	    ui_out->field_fmt ("valid", "0x%s", phex_nz (cont_bytes));
+	}
+      ui_out->text ("\n");
+    }
+}
+
 static simd_lanes_mask_t
 amdgpu_active_lanes_mask (struct gdbarch *gdbarch, thread_info *tp)
 {
@@ -2434,6 +2576,18 @@ INIT_GDB_FILE (amdgpu_tdep)
 		    amdgpu_supports_arch_info);
   gdb::observers::inferior_appeared.attach (amdgpu_observer_inferior_appeared,
 					    "amdgpu_tdep");
+
+  add_basic_prefix_cmd ("amdgpu", class_maintenance, _("\
+Commands for showing internal info about the AMDGPU target."),
+			&maintenance_info_amdgpu_list, 0,
+			&maintenanceinfolist);
+
+  add_cmd ("address-aliases", class_maintenance,
+	   amdgpu_info_address_aliases_command, _("\
+Show ADDRESS aliases across AMDGPU address spaces.\n\
+Usage: maintenance info amdgpu address-aliases ADDRESS.\n"),
+	   &maintenance_info_amdgpu_list);
+
 #if defined GDB_SELF_TEST
   selftests::register_test ("amdgpu-register-type-parse-flags-fields",
 			    amdgpu_register_type_parse_test);

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -45345,6 +45345,31 @@ packet history.
 @item maint info jit
 Print information about JIT code objects loaded in the current inferior.
 
+@kindex maint info amdgpu address-aliases
+@item maint info amdgpu address-aliases @var{expression}
+Evaluate @var{expression} to an address, and show the address it
+aliases to in every address space known to the current @acronym{AMD}
+@acronym{GPU} architecture.  The @samp{Valid for} column shows the
+number of consecutive bytes for which the aliasing is valid.
+
+For example:
+
+@smallexample
+(gdb) maintenance info amdgpu address-aliases &idx
+Address space                      Address         Valid for
+global                      0x7ff7f4600c00               0x4
+generic            generic#0x2000000000030             0x3d0
+private_wave            private_wave#0xc00               0x4
+private_lane             private_lane#0x30             0x3d0
+local                      <not reachable>               0x0
+@end smallexample
+
+This only works while stopped in an @acronym{AMD} @acronym{GPU} thread.
+Some address spaces are private to a wave or a lane of a wave, and
+@value{GDBN} converts using whichever wave and lane are currently
+selected.  Not every address is reachable from every space: if it isn't,
+the row for that space reads @samp{<not reachable>}.
+
 @anchor{maint info python-disassemblers}
 @kindex maint info python-disassemblers
 @item maint info python-disassemblers

--- a/gdb/testsuite/gdb.rocm/maint-info-amdgpu-address-aliases.cpp
+++ b/gdb/testsuite/gdb.rocm/maint-info-amdgpu-address-aliases.cpp
@@ -1,0 +1,60 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include "hip/hip_runtime.h"
+#include <vector>
+
+#include "rocm-test-utils.h"
+
+__global__ void __attribute__ ((optnone))
+kern (int *out)
+{
+  int idx = threadIdx.x;
+  __shared__ int gidx;
+  __shared__ int gdimx;
+
+  if (idx == 0)
+    {
+      int _gidx = blockIdx.x;
+      int _gdimx = blockDim.x;
+      gidx = _gidx;
+      gdimx = _gdimx;
+      volatile int *gidx_p = &gidx;
+      volatile int *gdimx_p = &gdimx;
+      volatile auto unused = gidx + gdimx; /* Break here.  */
+    }
+  __syncthreads ();
+
+  out[gidx * gdimx + idx] = threadIdx.x;
+}
+
+int
+main ()
+{
+  int *devOut;
+
+  CHECK (hipMalloc (&devOut, 64 * sizeof (int)));
+
+  kern<<<1, 1>>> (devOut);
+
+  std::vector<int> out (64);
+  CHECK (hipMemcpy (out.data (), devOut, 64 * sizeof (int),
+		    hipMemcpyDeviceToHost));
+
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/maint-info-amdgpu-address-aliases.exp
+++ b/gdb/testsuite/gdb.rocm/maint-info-amdgpu-address-aliases.exp
@@ -1,0 +1,103 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test the maint info amdgpu address-aliases command.
+
+load_lib rocm.exp
+
+standard_testfile .cpp
+
+require allow_hip_tests
+
+if {[prepare_for_testing "failed to prepare ${testfile}" $testfile $srcfile {debug hip}]} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+
+    # Test: command before any inferior is running (no thread selected).
+    gdb_test "maint info amdgpu address-aliases &main" \
+	"Current architecture is not AMDGPU\\." \
+	"address-aliases with no thread selected"
+
+    if {![runto_main]} {
+	return -1
+    }
+
+    # Test: command when focused on a host (CPU) thread, right after
+    # reaching main.
+    gdb_test "maint info amdgpu address-aliases &main" \
+	"Current architecture is not AMDGPU\\." \
+	"address-aliases on host thread"
+
+    gdb_breakpoint [gdb_get_line_number "Break here"] -allow-pending
+    gdb_continue_to_breakpoint "kern"
+
+    set asname "\[^ \t\r\n\]+"
+    set trailer "\[^\r\n\]*(?=\r\n)"
+
+    # Count address spaces known to the architecture.
+    set aspaces 0
+    gdb_test_multiple "maint print address-spaces" "" -lbl {
+	-re "\r\n${asname}\[ \t\]+$::decimal\[ \t\]+" {
+	    incr aspaces
+	    exp_continue
+	}
+	-re -wrap "" {
+	    # Done collecting.
+	}
+    }
+
+    set seen_header 0
+    set seen_address 0
+
+    # The actual output can vary, we want to verify if GDB doesn't
+    # have any latent error.
+    gdb_test_multiple "maint info amdgpu address-aliases &idx" "" -lbl {
+	-re "Address space\[ \t\]+Address\[ \t\]+Valid for${trailer}" {
+	    # Match the header.
+	    incr seen_header
+	    exp_continue
+	}
+
+	-re "^\r\n${asname}\[ \t\]+$::hex\[ \t\]+$::hex${trailer}" {
+	    # Match global address space.
+	    incr seen_address
+	    exp_continue
+	}
+
+	-re "^\r\n${asname}\[ \t\]+${asname}#$::hex\[ \t\]+($::hex|<null>)${trailer}" {
+	    # Match address space.
+	    incr seen_address
+	    exp_continue
+	}
+
+	-re "^\r\n${asname}\[ \t\]+<not reachable>\[ \t\]+($::hex|<null>)${trailer}" {
+	    # Match <not reachable> addresses.
+	    incr seen_address
+	    exp_continue
+	}
+
+	-re -wrap "" {
+	    # Done.  Every address space should have exactly one row.
+	    gdb_assert { $seen_header == 1 } "$gdb_test_name: seen header"
+	    gdb_assert { $seen_address == $aspaces } \
+		"$gdb_test_name: seen address space"
+	}
+    }
+}


### PR DESCRIPTION
## Motivation

Given an expression that evaluates to an address in some address space, show for each address space supported by the current AMDGPU architecture the aliasing address in that space, if any, along with the number of consecutive bytes for which the aliasing is valid.

This is purely a diagnostic aid: it queries amd_dbgapi_convert_address_space for every address space known to the architecture and reports "<not reachable>" for the ones the given address does not alias into.

## Test Plan

New `show_address_aliases.exp` test added.
