### PR TITLE
[testsuite] gdb.rocm/omp-target-multi-kernel: fix optimized-out x

### DIFF
--- a/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
@@ -27,13 +27,17 @@
 #define N 32
 
 #pragma omp declare target
-static int
+/* optnone prevents the compiler from optimizing x away, keeping it
+   readable in the debugger.  */
+static int __attribute__((optnone))
 square_dev (int x)
 {
   return x * x;
 }
 
-static int
+/* optnone prevents the compiler from optimizing x away, keeping it
+   readable in the debugger.  */
+static int __attribute__((optnone))
 cube_dev (int x)
 {
   return x * x * x;


### PR DESCRIPTION
At -O3 the compiler optimizes away the `x` parameter in `square_dev`
and `cube_dev`, causing `print x` to report `<optimized out>` and the
test to fail in the `-O3` and `-O3 -flto` CI jobs.

Mark both functions with `__attribute__((optnone))` to keep `x` live
and readable in the debugger.

Fixes: https://github.com/ROCm/ROCgdb/actions/runs/33192378358/job/98929943116