### PR TITLE
[amd-staging-rocgdb-16] gdb: Show __builtin_verbose_trap message in backtraces

### DIFF
--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -1839,6 +1839,32 @@ amd64_linux_fetch_hiperr_info (frame_info_ptr frame)
   return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGILL occurs.  */
+
+static bool
+amd64_linux_should_show_inline_frame (struct gdbarch *gdbarch,
+				      const struct symbol *func,
+				      enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to illegal instruction.
+     The ud2 instruction used by verbose traps on x86_64 generates SIGILL.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ILL)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static void
 amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
 			    int num_disp_step_buffers)
@@ -1897,6 +1923,11 @@ amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
   /* Extract hiperr info for 'catch hiperr'.  */
   set_gdbarch_fetch_hiperr_info
     (gdbarch, amd64_linux_fetch_hiperr_info);
+
+  /* Show verbose trap inline frames when stopped due to illegal
+     instruction.  */
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amd64_linux_should_show_inline_frame);
 }
 
 static void

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -2022,6 +2022,31 @@ amdgpu_supports_arch_info (const struct bfd_arch_info *info)
   return status == AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGABRT occurs.  */
+
+static bool
+amdgpu_should_show_inline_frame (struct gdbarch *gdbarch,
+				 const struct symbol *func,
+				 enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to abort signal.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ABRT)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static struct gdbarch *
 amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 {
@@ -2273,6 +2298,9 @@ amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
     error (_("amd_dbgapi_architecture_get_info failed"));
 
   set_gdbarch_decr_pc_after_break (gdbarch, pc_adjust);
+
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amdgpu_should_show_inline_frame);
 
   /* Get info about address spaces.  */
   size_t address_space_count;

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1619,6 +1619,18 @@ core_file_exec_context::environment () const
   return e;
 }
 
+/* See arch-utils.h.  */
+
+/* Default implementation: don't show inline frames.  */
+
+bool
+default_should_show_inline_frame (struct gdbarch *gdbarch,
+				  const struct symbol *func,
+				  enum gdb_signal stop_signal)
+{
+  return false;
+}
+
 void _initialize_gdbarch_utils ();
 void
 _initialize_gdbarch_utils ()

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -455,4 +455,9 @@ extern int default_supported_lanes_count (struct gdbarch *gdbarch,
 extern std::vector<addr_range> default_get_watchable_aliases
   (struct gdbarch *gdbarch, ptid_t ptid, int simd_lane, addr_range range);
 
+/* Default implementation of gdbarch_should_show_inline_frame.  */
+extern bool default_should_show_inline_frame
+  (struct gdbarch *gdbarch, const struct symbol *func,
+   enum gdb_signal stop_signal);
+
 #endif /* GDB_ARCH_UTILS_H */

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -273,6 +273,7 @@ struct gdbarch
   gdbarch_read_core_file_mappings_ftype *read_core_file_mappings = default_read_core_file_mappings;
   gdbarch_use_target_description_from_corefile_notes_ftype *use_target_description_from_corefile_notes = default_use_target_description_from_corefile_notes;
   gdbarch_core_parse_exec_context_ftype *core_parse_exec_context = default_core_parse_exec_context;
+  gdbarch_should_show_inline_frame_ftype *should_show_inline_frame = default_should_show_inline_frame;
 };
 
 /* Create a new ``struct gdbarch'' based on information provided by
@@ -567,6 +568,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of read_core_file_mappings, invalid_p == 0.  */
   /* Skip verify of use_target_description_from_corefile_notes, invalid_p == 0.  */
   /* Skip verify of core_parse_exec_context, invalid_p == 0.  */
+  /* Skip verify of should_show_inline_frame, invalid_p == 0.  */
   if (!log.empty ())
     internal_error (_("verify_gdbarch: the following are invalid ...%s"),
 		    log.c_str ());
@@ -1483,6 +1485,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: core_parse_exec_context = <%s>\n",
 	      host_address_to_string (gdbarch->core_parse_exec_context));
+  gdb_printf (file,
+	      "gdbarch_dump: should_show_inline_frame = <%s>\n",
+	      host_address_to_string (gdbarch->should_show_inline_frame));
   if (gdbarch->dump_tdep != NULL)
     gdbarch->dump_tdep (gdbarch, file);
 }
@@ -5842,4 +5847,21 @@ set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch,
 				     gdbarch_core_parse_exec_context_ftype core_parse_exec_context)
 {
   gdbarch->core_parse_exec_context = core_parse_exec_context;
+}
+
+bool
+gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal)
+{
+  gdb_assert (gdbarch != NULL);
+  gdb_assert (gdbarch->should_show_inline_frame != NULL);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_should_show_inline_frame called\n");
+  return gdbarch->should_show_inline_frame (gdbarch, func, stop_signal);
+}
+
+void
+set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch,
+				      gdbarch_should_show_inline_frame_ftype should_show_inline_frame)
+{
+  gdbarch->should_show_inline_frame = should_show_inline_frame;
 }

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1893,3 +1893,25 @@ extern void set_gdbarch_use_target_description_from_corefile_notes (struct gdbar
 typedef core_file_exec_context (gdbarch_core_parse_exec_context_ftype) (struct gdbarch *gdbarch, bfd *cbfd);
 extern core_file_exec_context gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, bfd *cbfd);
 extern void set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, gdbarch_core_parse_exec_context_ftype *core_parse_exec_context);
+
+/* Determine whether an inline frame should be shown in backtraces.
+
+   This hook is called when GDB encounters an inline frame to decide whether
+   it should be displayed to the user or hidden.  By default, inline frames
+   are hidden during normal stepping to provide a source-level debugging
+   experience.  However, some inline frames contain important diagnostic
+   information that should always be visible.
+
+   A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+   which embed crash diagnostic messages in specially-named inline frames.
+   When such a trap fires, the inline frame should be shown even though
+   inline frames are normally hidden.
+
+   The hook receives the inline frame's symbol and the signal that stopped
+   execution, allowing architecture-specific code to make the decision.
+
+   Return true if the inline frame should be shown, false to hide it. */
+
+typedef bool (gdbarch_should_show_inline_frame_ftype) (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+extern bool gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+extern void set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, gdbarch_should_show_inline_frame_ftype *should_show_inline_frame);

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2998,3 +2998,30 @@ which all assume current_inferior() is the one to read from.
     predefault="default_core_parse_exec_context",
     invalid=False,
 )
+
+Method(
+    comment="""
+Determine whether an inline frame should be shown in backtraces.
+
+This hook is called when GDB encounters an inline frame to decide whether
+it should be displayed to the user or hidden.  By default, inline frames
+are hidden during normal stepping to provide a source-level debugging
+experience.  However, some inline frames contain important diagnostic
+information that should always be visible.
+
+A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+which embed crash diagnostic messages in specially-named inline frames.
+When such a trap fires, the inline frame should be shown even though
+inline frames are normally hidden.
+
+The hook receives the inline frame's symbol and the signal that stopped
+execution, allowing architecture-specific code to make the decision.
+
+Return true if the inline frame should be shown, false to hide it.
+""",
+    type="bool",
+    name="should_show_inline_frame",
+    params=[("const struct symbol *", "func"), ("enum gdb_signal", "stop_signal")],
+    predefault="default_should_show_inline_frame",
+    invalid=False,
+)

--- a/gdb/inline-frame.c
+++ b/gdb/inline-frame.c
@@ -28,6 +28,7 @@
 #include "regcache.h"
 #include "symtab.h"
 #include "frame.h"
+#include "gdbarch.h"
 #include "cli/cli-cmds.h"
 #include "cli/cli-style.h"
 #include <algorithm>
@@ -432,10 +433,14 @@ skip_inline_frames (thread_info *thread, bpstat *stop_chain)
      which contains all of the inlined functions, we never skip this.  */
   int skipped_frames = 0;
 
+  struct gdbarch *gdbarch = get_frame_arch (get_current_frame ());
+  enum gdb_signal stop_signal = thread->stop_signal ();
+
   for (const auto sym : function_symbols)
     {
       if (stopped_by_user_bp_inline_frame (sym, stop_chain)
-	  || sym == function_symbols.back ())
+	  || sym == function_symbols.back ()
+	  || gdbarch_should_show_inline_frame (gdbarch, sym, stop_signal))
 	break;
 
       ++skipped_frames;

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+void
+test_trap_function ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_function ();
+  return 0;
+}

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap inline frames are shown when trap fires.
+# __builtin_verbose_trap is a Clang-only builtin, added in Clang 19.
+
+require {expr {[test_compiler_info clang*]
+	       && ![test_compiler_info {clang-1[0-8]-*}]
+	       && ![test_compiler_info {clang-[1-9]-*}]}}
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction with the
+# previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug c++}]} {
+    return
+}
+
+if {![runto test_trap_function]} {
+    return
+}
+
+# Continue to trigger the trap.
+gdb_test "continue" \
+    "received signal SIGILL.*" \
+    "received trap signal"
+
+# Verify verbose trap message appears in backtrace.
+gdb_test "bt" \
+    "This is verbose trap.*" \
+    "verbose trap message appears in backtrace"
+
+# Test single stepping to the trap line.
+# Expected: step should stop at __builtin_verbose_trap line, then
+# next step triggers the trap.
+clean_restart $testfile
+
+if {![runto_main]} {
+    return
+}
+
+# Set breakpoint at "int x = 1" line to avoid line table ambiguity
+# when running to the test function.
+set line_x [gdb_get_line_number "int x = 1"]
+gdb_breakpoint "$srcfile:$line_x"
+gdb_test "continue" "Breakpoint.*$line_x.*" "run to line $line_x"
+
+# Check for compiler line table bug using info line.
+# If the __builtin_verbose_trap line shows "contains no code",
+# the trap instruction is not mapped to that line (bug exists).
+set has_line_table_bug 0
+set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+gdb_test_multiple "info line $line_trap" "" {
+    -re "contains no code" {
+	set has_line_table_bug 1
+	exp_continue
+    }
+    -re -wrap "" {
+	pass $gdb_test_name
+    }
+}
+
+gdb_test_multiple "next" "step to trap line" {
+    -re -wrap "SIGILL.*" {
+	if {$has_line_table_bug} {
+	    xfail "$gdb_test_name (compiler line table bug)"
+	} else {
+	    fail "$gdb_test_name"
+	}
+    }
+    -re -wrap "__builtin_verbose_trap.*" {
+	pass $gdb_test_name
+
+	# Next step should trigger the trap.
+	gdb_test "next" "SIGILL.*" "step triggers trap"
+    }
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <hip/hip_runtime.h>
+
+__global__ void
+test_trap_kernel ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_kernel<<<1, 1>>> ();
+  return hipDeviceSynchronize () != hipSuccess;
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap PC is correctly adjusted.
+
+load_lib rocm.exp
+require allow_hip_tests
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction
+# with the previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+with_rocm_gpu_lock {
+    if {![runto test_trap_kernel allow-pending]} {
+	return
+    }
+
+    # Continue to trigger the trap.
+    gdb_test "continue" \
+	"received signal SIGABRT.*" \
+	"received trap signal"
+
+    # Check PC points to trap instruction.
+    gdb_test "x/i \$pc" \
+	"s_trap.*" \
+	"PC points to trap instruction"
+
+    # Verify verbose trap message appears in backtrace.
+    gdb_test "bt" \
+	"This is verbose trap.*" \
+	"verbose trap message appears in backtrace"
+
+    # Test single stepping to the trap line.
+    # Expected: step should stop at __builtin_verbose_trap line, then
+    # next step triggers the trap.
+    clean_restart $testfile
+
+    if {![runto test_trap_kernel allow-pending]} {
+	return
+    }
+
+    # Check for compiler line table bug using info line.
+    # If the __builtin_verbose_trap line shows "contains no code",
+    # the trap instruction is not mapped to that line (bug exists).
+    set has_line_table_bug 0
+    set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+    gdb_test_multiple "info line $line_trap" "" {
+	-re "contains no code" {
+	    set has_line_table_bug 1
+	    exp_continue
+	}
+	-re -wrap "" {
+	    pass $gdb_test_name
+	}
+    }
+
+    gdb_test_multiple "next" "step to trap line" {
+	-re -wrap "SIGABRT.*" {
+	    if {$has_line_table_bug} {
+		xfail "$gdb_test_name (compiler line table bug)"
+	    } else {
+		fail "$gdb_test_name"
+	    }
+	}
+	-re -wrap "__builtin_verbose_trap.*" {
+	    pass $gdb_test_name
+
+	    # Next step should trigger the trap.
+	    gdb_test "next" "SIGABRT.*" "step triggers trap"
+	}
+    }
+}


### PR DESCRIPTION
__builtin_verbose_trap is a Clang builtin that allows embedding custom trap messages in the binary for better crash diagnostics.  When called, it emits a trap instruction and creates an artificial inline frame with a specially-formatted name: __clang_trap_msg$<category>$<message>.

Currently, when a program hits a verbose trap, GDB hides this inline frame by default (as it does for all inline frames during normal stepping).  This means the trap message is not visible in backtraces, defeating the purpose of verbose traps.

Before this fix, a backtrace after hitting a verbose trap shows:

    #0  test_trap_kernel () at test.cpp:24

After this fix:

    #0  __clang_trap_msg$check verbose$This is verbose trap! ()
        at test.cpp:23
    #1  test_trap_kernel () at test.cpp:24

This affects both CPU (x86_64) and GPU (AMDGPU) targets, though with different trap mechanisms:
- CPU: ud2 instruction generates SIGILL
- GPU: s_trap 2 instruction generates SIGABRT

To fix this, add a new gdbarch hook 'should_show_inline_frame' that allows architecture-specific code to decide whether an inline frame should be shown.  The hook receives the symbol and the stop signal, returning true if the frame should be displayed.

The hook is implemented for:
- amd64-linux: checks for SIGILL + __clang_trap_msg$ prefix
- amdgpu: checks for SIGABRT + __clang_trap_msg$ prefix

The signal check ensures the frame is only shown when the trap actually fires, preserving normal stepping behavior where inline frames are hidden.

Bug: AIROCGDB-558

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
