### PR TITLE
[amd-staging-rocgdb-16] ROCgdb cherry picks from origin/amd-staging (2026-09-02)

### DIFF
--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,6 +1,6 @@
 {
-  "therock_commit_ref": "f438028b32ad093ad56709f3bd26ee02d958c477",
-  "therock_commit_created": "2026-08-21T17:07:33Z",
+  "therock_commit_ref": "d0a3a81db89bb08ce904253bd1e455b0e070d596",
+  "therock_commit_created": "2026-09-02T03:29:20Z",
   "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:cf4f6d9909056906e4a1c0bc4c245658a0af4c6a6174082a86adfa2d518b7aeb",
   "build_image_created": "2026-08-17T22:45:41.087330949Z"
 }

--- a/.github/scripts/automerge.md
+++ b/.github/scripts/automerge.md
@@ -1,0 +1,85 @@
+# Automerge Workflow
+
+Automatically syncs `sourceware/master` into `origin/amd-staging` every 6 hours,
+opening GitHub PRs for CI validation or conflict resolution as needed.
+
+## Files
+
+- `.github/workflows/automerge.yml` — GitHub Actions workflow definition.
+- `.github/scripts/automerge.py` — Python sync script invoked by the workflow.
+
+## Triggers
+
+| Event                 | Condition                                             | Effect            |
+| --------------------- | ----------------------------------------------------- | ----------------- |
+| Scheduled             | Every 6 hours                                         | Normal sync run   |
+| `workflow_dispatch`   | Manual                                                | Normal sync run   |
+| `pull_request` closed | PR merged + label `merge-testing` or `merge-conflict` | Immediate re-sync |
+
+## Sync Logic
+
+Each run follows these steps:
+
+1. **Clone or reuse** a local clone of `ROCm/ROCgdb` in `$WORKSPACE/rocgdb_sync/`.
+2. **Fetch** `sourceware/master` and `origin/amd-staging`, then immediately fast-forward `origin/master` to `sourceware/master` to keep the mirror current.
+3. **Gate** — if a fast-forward or conflict PR is already open, skip and exit.
+4. **Compute** the commit range: `merge-base(amd-staging, sourceware/master)..sourceware/master`.
+5. **Probe** — walk commits oldest-to-newest on a throwaway branch off `amd-staging`
+   to find the largest clean-merging prefix.
+6. **Act** based on the probe result:
+
+### 6a. All commits merge cleanly
+
+Opens a **fast-forward PR** covering the full range. CI must pass before anyone
+merges it. Once merged, the `pull_request` closed trigger fires another sync run
+to pick up any further upstream commits.
+
+### 6b. Partial clean prefix
+
+Opens a **fast-forward PR** for the clean prefix only. The conflict commit is left
+for the next run — after the FF PR merges, the re-sync will find the conflict and
+open a conflict PR then.
+
+### 6c. No clean commits
+
+Opens a **conflict PR** directly against `amd-staging`. The PR is labeled
+`ci:skip` to suppress CI until conflicts are resolved manually. After the PR is
+merged, the `pull_request` closed trigger fires another sync run.
+
+## PR Types
+
+### Fast-forward PR
+
+- **Branch**: `users/github/master-to-amd-staging-ff-YYYY-MM-DD-<hash>`
+- **Label**: `merge-testing`
+- **Base**: `amd-staging`
+- **Purpose**: CI gate before fast-forwarding upstream commits into staging.
+
+### Conflict PR
+
+- **Branch**: `users/github/master-to-amd-staging-conflict-YYYY-MM-DD-<hash>`
+- **Labels**: `merge-conflict`, `ci:skip`
+- **Base**: `amd-staging`
+- **Purpose**: Signals a merge conflict that requires manual resolution.
+  Remove the `ci:skip` label once conflicts are resolved to allow CI to run.
+
+## Configuration
+
+Environment variables:
+
+| Variable / flag      | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. The clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
+
+Key constants at the top of `automerge.py`:
+
+| Constant                 | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `ROCGDB_REPO`            | GitHub repo slug (`ROCm/ROCgdb`)                         |
+| `SOURCEWARE_URL`         | Upstream GDB repository URL                              |
+| `FF_BRANCH_PREFIX`       | Branch prefix for fast-forward PRs                       |
+| `CONFLICT_BRANCH_PREFIX` | Branch prefix for conflict PRs                           |
+| `FF_LABEL`               | Label applied to fast-forward PRs (`merge-testing`)      |
+| `CONFLICT_LABEL`         | Label applied to conflict PRs (`merge-conflict`)         |
+| `CI_SKIP_LABEL`          | Label applied to conflict PRs to suppress CI (`ci:skip`) |
+| `RETRY_DELAYS`           | Sleep intervals (seconds) between network retries        |

--- a/.github/scripts/automerge.md
+++ b/.github/scripts/automerge.md
@@ -1,85 +1,92 @@
 # Automerge Workflow
 
-Automatically syncs `sourceware/master` into `origin/amd-staging` every 6 hours,
-opening GitHub PRs for CI validation or conflict resolution as needed.
+Automatically syncs the configured upstream branch into the target branch every
+6 hours, opening GitHub PRs for CI validation or conflict resolution as needed.
 
 ## Files
 
 - `.github/workflows/automerge.yml` — GitHub Actions workflow definition.
 - `.github/scripts/automerge.py` — Python sync script invoked by the workflow.
+- `.github/scripts/test_automerge.py` — Unit tests for automerge.py.
 
 ## Triggers
 
-| Event                 | Condition                                             | Effect            |
-| --------------------- | ----------------------------------------------------- | ----------------- |
-| Scheduled             | Every 6 hours                                         | Normal sync run   |
-| `workflow_dispatch`   | Manual                                                | Normal sync run   |
-| `pull_request` closed | PR merged + label `merge-testing` or `merge-conflict` | Immediate re-sync |
+| Event               | Effect          |
+| ------------------- | --------------- |
+| Scheduled (6 hours) | Normal sync run |
+| `workflow_dispatch` | Manual run; exposes a `dry_run` boolean input |
+
+## Repository Variables
+
+Both variables must be set in the repository settings before the workflow runs:
+
+| Variable                    | Example       | Description                        |
+| --------------------------- | ------------- | ---------------------------------- |
+| `AUTOMERGE_TARGET_BRANCH`   | `amd-staging` | Branch to merge upstream commits into |
+| `AUTOMERGE_UPSTREAM_BRANCH` | `master`      | Upstream branch to pull from       |
+
+## Dry-Run Mode
+
+Pass `--dry-run` on the CLI, or enable the `dry_run` input in a manual
+`workflow_dispatch` run. In dry-run mode the script fetches and probes normally
+but skips all pushes and PR creation, printing what it would do instead.
 
 ## Sync Logic
 
 Each run follows these steps:
 
-1. **Clone or reuse** a local clone of `ROCm/ROCgdb` in `$WORKSPACE/rocgdb_sync/`.
-2. **Fetch** `sourceware/master` and `origin/amd-staging`, then immediately fast-forward `origin/master` to `sourceware/master` to keep the mirror current.
-3. **Gate** — if a fast-forward or conflict PR is already open, skip and exit.
-4. **Compute** the commit range: `merge-base(amd-staging, sourceware/master)..sourceware/master`.
-5. **Probe** — walk commits oldest-to-newest on a throwaway branch off `amd-staging`
+1. **Acquire repo** — use an existing clone passed via `--repo`, or clone/reuse
+   one in `$WORKSPACE/rocgdb_sync/`. In GHA the checked-out workspace is passed
+   as `--repo`, avoiding a redundant clone.
+2. **Fetch upstream and update mirror** — fetch the upstream branch from
+   sourceware, then fast-forward `origin/<upstream>` to keep the mirror current.
+3. **Gate** — if a conflict-free or conflict PR is already open, skip and exit.
+4. **Fetch target** — fetch `origin/<target>` (deferred until after the gate to
+   avoid unnecessary work when a PR is already open).
+5. **Compute** the commit range: `merge-base(TARGET, upstream)..upstream`.
+6. **Probe** — walk commits oldest-to-newest on a throwaway branch off the target
    to find the largest clean-merging prefix.
-6. **Act** based on the probe result:
+7. **Act** based on the probe result:
 
-### 6a. All commits merge cleanly
+### 7a. All commits merge cleanly
 
-Opens a **fast-forward PR** covering the full range. CI must pass before anyone
-merges it. Once merged, the `pull_request` closed trigger fires another sync run
-to pick up any further upstream commits.
+Opens a **conflict-free PR** covering the full range. CI must pass before anyone
+merges it.
 
-### 6b. Partial clean prefix
+### 7b. Partial clean prefix
 
-Opens a **fast-forward PR** for the clean prefix only. The conflict commit is left
-for the next run — after the FF PR merges, the re-sync will find the conflict and
-open a conflict PR then.
+Opens a **conflict-free PR** for the clean prefix only. The conflict commit is
+left for the next scheduled run.
 
-### 6c. No clean commits
+### 7c. No clean commits
 
-Opens a **conflict PR** directly against `amd-staging`. The PR is labeled
-`ci:skip` to suppress CI until conflicts are resolved manually. After the PR is
-merged, the `pull_request` closed trigger fires another sync run.
+Opens a **conflict PR** directly against the target branch. The PR is labeled
+`ci:skip` to suppress CI until conflicts are resolved manually.
 
 ## PR Types
 
-### Fast-forward PR
+### Conflict-free PR
 
-- **Branch**: `users/github/master-to-amd-staging-ff-YYYY-MM-DD-<hash>`
+- **Branch**: `users/github/<upstream>-to-<target>-conflict-free-YYYY-MM-DD-<hash>`
 - **Label**: `merge-testing`
-- **Base**: `amd-staging`
-- **Purpose**: CI gate before fast-forwarding upstream commits into staging.
+- **Base**: target branch
+- **Purpose**: CI gate before landing upstream commits into the target branch.
 
 ### Conflict PR
 
-- **Branch**: `users/github/master-to-amd-staging-conflict-YYYY-MM-DD-<hash>`
+- **Branch**: `users/github/<upstream>-to-<target>-conflict-YYYY-MM-DD-<hash>`
 - **Labels**: `merge-conflict`, `ci:skip`
-- **Base**: `amd-staging`
-- **Purpose**: Signals a merge conflict that requires manual resolution.
+- **Base**: target branch
+- **Purpose**: Signals a merge conflict requiring manual resolution.
   Remove the `ci:skip` label once conflicts are resolved to allow CI to run.
 
 ## Configuration
 
-Environment variables:
-
-| Variable / flag      | Description                                                                 |
-| -------------------- | --------------------------------------------------------------------------- |
-| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. The clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
-
-Key constants at the top of `automerge.py`:
-
-| Constant                 | Description                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `ROCGDB_REPO`            | GitHub repo slug (`ROCm/ROCgdb`)                         |
-| `SOURCEWARE_URL`         | Upstream GDB repository URL                              |
-| `FF_BRANCH_PREFIX`       | Branch prefix for fast-forward PRs                       |
-| `CONFLICT_BRANCH_PREFIX` | Branch prefix for conflict PRs                           |
-| `FF_LABEL`               | Label applied to fast-forward PRs (`merge-testing`)      |
-| `CONFLICT_LABEL`         | Label applied to conflict PRs (`merge-conflict`)         |
-| `CI_SKIP_LABEL`          | Label applied to conflict PRs to suppress CI (`ci:skip`) |
-| `RETRY_DELAYS`           | Sleep intervals (seconds) between network retries        |
+| Variable / flag             | Description                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| `AUTOMERGE_TARGET_BRANCH`   | Required. Branch to merge into.                                                  |
+| `AUTOMERGE_UPSTREAM_BRANCH` | Required. Upstream branch to pull from.                                          |
+| `GITHUB_REPOSITORY`         | Required. Set automatically by GitHub Actions (`owner/repo`).                    |
+| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. Clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
+| `--repo`                    | Path to an existing ROCgdb clone to use directly, skipping the clone step. Used in GHA to reuse the `actions/checkout` workspace. |
+| `--dry-run`                 | Skip all pushes and PR creation; print what would happen instead.                |

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Sync ROCgdb sourceware/master into origin/amd-staging.
+
+Fetches the upstream sourceware master, fast-forwards origin/master to match,
+then merges cleanly into origin/amd-staging. On conflict, pushes a conflict
+branch and opens a PR for manual resolution.
+"""
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+ROCGDB_REPO = "ROCm/ROCgdb"
+ROCGDB_ORIGIN_URL = f"https://github.com/{ROCGDB_REPO}.git"
+SOURCEWARE_URL = "https://sourceware.org/git/binutils-gdb.git"
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Sync sourceware/master into origin/amd-staging.")
+    p.add_argument(
+        "--workspace",
+        metavar="DIR",
+        help="Root directory for the working clone (overrides $WORKSPACE). "
+             "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and probe as normal, but skip all pushes and PR creation.",
+    )
+    return p.parse_args()
+
+
+_args = _parse_args()
+DRY_RUN: bool = _args.dry_run
+_workspace = _args.workspace or os.environ.get("WORKSPACE", "")
+if _workspace:
+    _workspace_path = Path(_workspace).resolve()
+    if not _workspace_path.exists():
+        print(
+            f"Error: workspace '{_workspace}' is not a valid path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    WORK_DIR = _workspace_path / "rocgdb_sync"
+else:
+    WORK_DIR = Path.cwd() / "rocgdb_sync"
+
+# Never pass secrets as CLI args — use env vars (e.g. GH_TOKEN) instead.
+
+CONFLICT_BRANCH_PREFIX = "users/github/master-to-amd-staging-conflict"
+FF_BRANCH_PREFIX = "users/github/master-to-amd-staging-ff"
+CONFLICT_LABEL = "merge-conflict"
+FF_LABEL = "merge-testing"
+CI_SKIP_LABEL = "ci:skip"
+
+# Sleep durations (seconds) between successive network attempts.
+# Total attempts = len(RETRY_DELAYS) + 1.
+RETRY_DELAYS = [60, 120]
+
+
+# ---------------------------------------------------------------------------
+# Subprocess / git helpers
+# ---------------------------------------------------------------------------
+
+
+def run(
+    cmd: list[str],
+    cwd=None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+    redact: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess, printing the command (with any redacted values masked)."""
+    display_cmd = cmd
+    if redact:
+        display_cmd = [
+            "<redacted>" if any(r in arg for r in redact) else arg for arg in cmd
+        ]
+    print(f"[RUN] {' '.join(shlex.quote(str(a)) for a in display_cmd)}")
+    merged_env = {**os.environ, **(env or {})}
+    result = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, env=merged_env
+    )
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.returncode != 0 and result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, result.stdout, result.stderr
+        )
+    return result
+
+
+def _is_network_error(exc: subprocess.CalledProcessError) -> bool:
+    stderr = (exc.stderr or "").lower()
+    keywords = (
+        "could not resolve",
+        "unable to connect",
+        "connection refused",
+        "connection timed out",
+        "network is unreachable",
+        "no route to host",
+        "fatal: unable to access",
+        "ssh: connect",
+    )
+    return any(k in stderr for k in keywords)
+
+
+def run_net(cmd: list[str], cwd=None) -> subprocess.CompletedProcess:
+    """Run a network git command, retrying on transient connectivity errors."""
+    max_attempts = len(RETRY_DELAYS) + 1
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return run(cmd, cwd=cwd)
+        except subprocess.CalledProcessError as exc:
+            if not _is_network_error(exc):
+                raise
+            last_exc = exc
+            if attempt < max_attempts:
+                delay = RETRY_DELAYS[attempt - 1]
+                print(
+                    f"Network error (attempt {attempt}/{max_attempts}), "
+                    f"retrying in {delay}s…"
+                )
+                time.sleep(delay)
+            else:
+                print(f"Network error (attempt {attempt}/{max_attempts}), giving up.")
+    raise ConnectivityError() from last_exc
+
+
+class ConnectivityError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (gh CLI)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_label(label: str, color: str) -> None:
+    result = run(
+        [
+            "gh",
+            "label",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--search",
+            label,
+            "--json",
+            "name",
+        ],
+    )
+    existing = [entry["name"] for entry in json.loads(result.stdout or "[]")]
+    if label not in existing:
+        run(["gh", "label", "create", label, "--repo", ROCGDB_REPO, "--color", color])
+
+
+def open_conflict_pr(
+    branch: str,
+    merge_base_sha: str,
+    conflict_commit: str,
+    conflicted_files: list[str],
+) -> str:
+    compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{merge_base_sha[:12]}...{conflict_commit[:12]}"
+    file_list = "\n".join(f"- `{f}`" for f in conflicted_files)
+    title = (
+        f"ROCgdb master → amd-staging conflict: "
+        f"{merge_base_sha[:12]}..{conflict_commit[:12]}"
+    )
+    body = (
+        f"## ROCgdb master → amd-staging merge conflict\n\n"
+        f"**Commits being merged:** [{merge_base_sha[:12]}...{conflict_commit[:12]}]({compare_url})\n\n"
+        f"**Conflicted files:**\n{file_list}\n\n"
+        f"Please resolve the conflicts, remove the `{CI_SKIP_LABEL}` label, "
+        f"validate in CI, then merge."
+    )
+
+    _ensure_label(CONFLICT_LABEL, "e11d48")
+    _ensure_label(CI_SKIP_LABEL, "f59e0b")
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            CONFLICT_LABEL,
+            "--label",
+            CI_SKIP_LABEL,
+        ]
+    )
+    pr_url = result.stdout.strip()
+    print(f"Conflict PR opened: {pr_url}")
+    return pr_url
+
+
+def find_open_conflict_pr() -> str | None:
+    """Return the URL of an open conflict PR if one exists, else None."""
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--state",
+            "open",
+            "--label",
+            CONFLICT_LABEL,
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+    )
+    url = (result.stdout or "").strip()
+    return url if url else None
+
+
+def open_ff_pr(
+    branch: str,
+    first_commit: str,
+    last_commit: str,
+) -> str:
+    compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{first_commit[:12]}...{last_commit[:12]}"
+    title = (
+        f"ROCgdb master → amd-staging fast-forward: "
+        f"{first_commit[:12]}..{last_commit[:12]}"
+    )
+    body = (
+        f"## ROCgdb master → amd-staging fast-forward merge\n\n"
+        f"**Commits being merged:** [{first_commit[:12]}...{last_commit[:12]}]({compare_url})\n\n"
+        f"This PR was opened automatically by the automerge workflow. "
+        f"Please validate CI, then merge."
+    )
+
+    _ensure_label(FF_LABEL, "0075ca")
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            FF_LABEL,
+        ]
+    )
+    pr_url = result.stdout.strip()
+    print(f"Fast-forward PR opened: {pr_url}")
+    return pr_url
+
+
+def find_open_ff_pr() -> str | None:
+    """Return the URL of an open fast-forward PR if one exists, else None."""
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--state",
+            "open",
+            "--label",
+            FF_LABEL,
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+    )
+    url = (result.stdout or "").strip()
+    return url if url else None
+
+
+# ---------------------------------------------------------------------------
+# Core sync logic
+# ---------------------------------------------------------------------------
+
+
+def push_master_mirror(repo: Path) -> None:
+    """Fast-forward origin/master to match sourceware/master."""
+    print("Fast-forwarding origin/master to sourceware/master…")
+    run_net(
+        ["git", "push", "origin", "sourceware/master:refs/heads/master"],
+        cwd=repo,
+    )
+
+
+def probe_clean_prefix(
+    repo: Path,
+    commits: list[str],
+) -> tuple[str | None, str | None]:
+    """
+    Walk commits oldest-to-newest on a throwaway branch off origin/amd-staging.
+    Returns (last_clean_commit, first_conflict_commit).
+    """
+    run(["git", "checkout", "-B", "probe", "origin/amd-staging"], cwd=repo)
+
+    last_clean = None
+    first_conflict = None
+
+    try:
+        for commit in commits:
+            result = run(["git", "merge", "--no-edit", commit], cwd=repo, check=False)
+            if result.returncode != 0:
+                run(["git", "merge", "--abort"], cwd=repo)
+                first_conflict = commit
+                break
+            last_clean = commit
+    finally:
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo)
+        run(["git", "branch", "-D", "probe"], cwd=repo)
+
+    return last_clean, first_conflict
+
+
+def main() -> None:
+    WORK_DIR.mkdir(parents=True, exist_ok=True)
+    repo = WORK_DIR / "binutils-gdb"
+
+    try:
+        # ------------------------------------------------------------------ #
+        # 1. Clone or reuse.                                                   #
+        # ------------------------------------------------------------------ #
+        if (repo / ".git").exists():
+            print(f"Reusing existing clone at {repo}…")
+        else:
+            print(f"Cloning {ROCGDB_REPO}…")
+            run_net(["git", "clone", ROCGDB_ORIGIN_URL, str(repo)])
+
+        remotes = run(["git", "remote"], cwd=repo).stdout.split()
+        if "sourceware" not in remotes:
+            run(["git", "remote", "add", "sourceware", SOURCEWARE_URL], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 2. Fetch sourceware/master and origin/amd-staging.                  #
+        # ------------------------------------------------------------------ #
+        print("Fetching sourceware/master…")
+        run_net(["git", "fetch", "sourceware", "master"], cwd=repo)
+
+        print("Fetching origin/amd-staging…")
+        run_net(["git", "fetch", "origin", "amd-staging"], cwd=repo)
+
+        if not DRY_RUN:
+            push_master_mirror(repo)
+
+        # ------------------------------------------------------------------ #
+        # 3. Skip if a conflict or fast-forward PR is already open.           #
+        # ------------------------------------------------------------------ #
+        existing_conflict_pr = find_open_conflict_pr()
+        if existing_conflict_pr:
+            print(
+                f"Open conflict PR found: {existing_conflict_pr}\n"
+                "Skipping merge — resolve the PR first."
+            )
+            return
+
+        existing_ff_pr = find_open_ff_pr()
+        if existing_ff_pr:
+            print(
+                f"Open fast-forward PR found: {existing_ff_pr}\n"
+                "Skipping merge — wait for the PR to be merged first."
+            )
+            return
+
+        # ------------------------------------------------------------------ #
+        # 4. Determine the commit range to merge.                             #
+        # ------------------------------------------------------------------ #
+        merge_base_sha = run(
+            ["git", "merge-base", "origin/amd-staging", "sourceware/master"],
+            cwd=repo,
+        ).stdout.strip()
+
+        log_out = run(
+            [
+                "git",
+                "log",
+                "--format=%H",
+                "--reverse",
+                f"{merge_base_sha}..sourceware/master",
+            ],
+            cwd=repo,
+        ).stdout.strip()
+
+        if not log_out:
+            print(
+                "amd-staging is already up to date with sourceware/master. Nothing to do."
+            )
+            return
+
+        commits = log_out.splitlines()
+        print(
+            f"Found {len(commits)} new commit(s) to merge "
+            f"({commits[0][:12]}..{commits[-1][:12]})."
+        )
+
+        # ------------------------------------------------------------------ #
+        # 5. Set up local amd-staging branch.                                 #
+        # ------------------------------------------------------------------ #
+        if not DRY_RUN:
+            run(
+                ["git", "checkout", "-B", "amd-staging", "origin/amd-staging"],
+                cwd=repo,
+            )
+
+        # ------------------------------------------------------------------ #
+        # 6. Probe for the largest clean prefix.                              #
+        # ------------------------------------------------------------------ #
+        print("Probing for clean merge prefix…")
+        last_clean, first_conflict = probe_clean_prefix(repo, commits)
+
+        # Probe leaves the repo on detached HEAD; return to the local branch.
+        if not DRY_RUN:
+            run(["git", "checkout", "amd-staging"], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 7a. All commits apply cleanly → open a fast-forward PR.            #
+        # ------------------------------------------------------------------ #
+        if first_conflict is None:
+            print(f"All {len(commits)} commit(s) merge cleanly.")
+            ff_branch = (
+                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            )
+            if DRY_RUN:
+                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+            else:
+                run(["git", "checkout", "-B", ff_branch], cwd=repo)
+                run(["git", "merge", "--no-edit", commits[-1]], cwd=repo)
+                run_net(["git", "push", "origin", ff_branch], cwd=repo)
+                open_ff_pr(
+                    branch=ff_branch,
+                    first_commit=merge_base_sha,
+                    last_commit=commits[-1],
+                )
+            return
+
+        # ------------------------------------------------------------------ #
+        # 7b. Partial clean prefix → open a fast-forward PR for clean range. #
+        # ------------------------------------------------------------------ #
+        if last_clean is not None:
+            print(f"Clean prefix ends at {last_clean[:12]}. Opening fast-forward PR…")
+            ff_branch = (
+                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            )
+            if DRY_RUN:
+                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+            else:
+                run(["git", "checkout", "-B", ff_branch], cwd=repo)
+                run(["git", "merge", "--no-edit", last_clean], cwd=repo)
+                run_net(["git", "push", "origin", ff_branch], cwd=repo)
+                open_ff_pr(
+                    branch=ff_branch,
+                    first_commit=merge_base_sha,
+                    last_commit=last_clean,
+                )
+            return
+        else:
+            print("No clean commits to merge; first commit already conflicts.")
+
+        # ------------------------------------------------------------------ #
+        # 8. Create conflict branch and open PR.                              #
+        # ------------------------------------------------------------------ #
+        conflict_branch = (
+            f"{CONFLICT_BRANCH_PREFIX}-{date.today().isoformat()}-{first_conflict[:8]}"
+        )
+
+        conflict_info = run(
+            ["git", "log", "-1", "--format=%H %s (%aN <%aE>)", first_conflict],
+            cwd=repo,
+        ).stdout.strip()
+        print(f"\nConflict commit: {conflict_info}")
+
+        if DRY_RUN:
+            print(f"[DRY RUN] would push {conflict_branch} and open conflict PR.")
+        else:
+            # Checkout a fresh conflict branch from the current amd-staging state.
+            run(["git", "checkout", "-B", conflict_branch], cwd=repo)
+            run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
+
+            conflicted_files = (
+                run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
+                .stdout.strip()
+                .splitlines()
+            )
+            print("Conflicted files:")
+            for f in conflicted_files:
+                print(f"  {f}")
+
+            # Stage and commit the conflict markers so the branch carries a diff
+            # that gh pr create can open (the branch would otherwise be identical
+            # to amd-staging and gh would reject it with "no commits between...").
+            run(["git", "add", "-A"], cwd=repo)
+            run(
+                [
+                    "git", "commit", "--no-verify", "-m",
+                    f"Merge {first_conflict[:12]} into amd-staging (unresolved conflicts)",
+                ],
+                cwd=repo,
+            )
+
+            run_net(["git", "push", "origin", conflict_branch], cwd=repo)
+            open_conflict_pr(
+                branch=conflict_branch,
+                merge_base_sha=merge_base_sha,
+                conflict_commit=first_conflict,
+                conflicted_files=conflicted_files,
+            )
+
+    except ConnectivityError:
+        print("Connectivity error: all retries exhausted.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -28,12 +28,14 @@ SOURCEWARE_URL = "https://sourceware.org/git/binutils-gdb.git"
 
 
 def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Sync sourceware/master into origin/amd-staging.")
+    p = argparse.ArgumentParser(
+        description="Sync sourceware/master into origin/amd-staging."
+    )
     p.add_argument(
         "--workspace",
         metavar="DIR",
         help="Root directory for the working clone (overrides $WORKSPACE). "
-             "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
+        "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
     )
     p.add_argument(
         "--dry-run",
@@ -533,7 +535,10 @@ def main() -> None:
             run(["git", "add", "-A"], cwd=repo)
             run(
                 [
-                    "git", "commit", "--no-verify", "-m",
+                    "git",
+                    "commit",
+                    "--no-verify",
+                    "-m",
                     f"Merge {first_conflict[:12]} into amd-staging (unresolved conflicts)",
                 ],
                 cwd=repo,

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -454,6 +454,21 @@ def main() -> None:
         print(f"Fetching origin/{TARGET_BRANCH}…")
         run_net(["git", "fetch", "origin", TARGET_BRANCH], cwd=repo)
 
+        # Unshallow if needed so that merge-base can find the common ancestor
+        # between origin/TARGET_BRANCH and sourceware/UPSTREAM_BRANCH.
+        is_shallow = (
+            run(
+                ["git", "rev-parse", "--is-shallow-repository"],
+                cwd=repo,
+            ).stdout.strip()
+            == "true"
+        )
+        if is_shallow:
+            print(f"Repo is shallow; unshallowing origin/{TARGET_BRANCH}…")
+            run_net(
+                ["git", "fetch", "--unshallow", "origin", TARGET_BRANCH], cwd=repo
+            )
+
         # ------------------------------------------------------------------ #
         # 5. Determine the commit range to merge.                             #
         # ------------------------------------------------------------------ #

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-"""Sync ROCgdb sourceware/master into origin/amd-staging.
+"""Sync ROCgdb upstream branch into the target branch.
 
-Fetches the upstream sourceware master, fast-forwards origin/master to match,
-then merges cleanly into origin/amd-staging. On conflict, pushes a conflict
+Fetches the upstream branch, fast-forwards the origin mirror to match,
+then merges cleanly into the target branch. On conflict, pushes a conflict
 branch and opens a PR for manual resolution.
 """
 
@@ -22,20 +22,52 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-ROCGDB_REPO = "ROCm/ROCgdb"
+SOURCEWARE_URL = "git://sourceware.org/git/binutils-gdb.git"
+SOURCEWARE_REMOTE = "sourceware"
+
+_rocgdb_repo = os.environ.get("GITHUB_REPOSITORY", "")
+if not _rocgdb_repo:
+    print(
+        "Error: GITHUB_REPOSITORY environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+ROCGDB_REPO = _rocgdb_repo
 ROCGDB_ORIGIN_URL = f"https://github.com/{ROCGDB_REPO}.git"
-SOURCEWARE_URL = "https://sourceware.org/git/binutils-gdb.git"
+
+_target_branch = os.environ.get("AUTOMERGE_TARGET_BRANCH", "")
+if not _target_branch:
+    print(
+        "Error: AUTOMERGE_TARGET_BRANCH environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+TARGET_BRANCH = _target_branch
+
+_upstream_branch = os.environ.get("AUTOMERGE_UPSTREAM_BRANCH", "")
+if not _upstream_branch:
+    print(
+        "Error: AUTOMERGE_UPSTREAM_BRANCH environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+UPSTREAM_BRANCH = _upstream_branch
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Sync sourceware/master into origin/amd-staging."
+        description=f"Sync {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH} into origin/{TARGET_BRANCH}."
     )
     p.add_argument(
         "--workspace",
         metavar="DIR",
         help="Root directory for the working clone (overrides $WORKSPACE). "
         "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
+    )
+    p.add_argument(
+        "--repo",
+        metavar="DIR",
+        help="Path to an existing ROCgdb clone to use directly, skipping the clone step.",
     )
     p.add_argument(
         "--dry-run",
@@ -62,10 +94,11 @@ else:
 
 # Never pass secrets as CLI args — use env vars (e.g. GH_TOKEN) instead.
 
-CONFLICT_BRANCH_PREFIX = "users/github/master-to-amd-staging-conflict"
-FF_BRANCH_PREFIX = "users/github/master-to-amd-staging-ff"
+_branch_infix = f"{UPSTREAM_BRANCH}-to-{TARGET_BRANCH}".replace("/", "-")
+CONFLICT_BRANCH_PREFIX = f"users/github/{_branch_infix}-conflict"
+CONFLICT_FREE_BRANCH_PREFIX = f"users/github/{_branch_infix}-conflict-free"
 CONFLICT_LABEL = "merge-conflict"
-FF_LABEL = "merge-testing"
+CONFLICT_FREE_LABEL = "merge-testing"
 CI_SKIP_LABEL = "ci:skip"
 
 # Sleep durations (seconds) between successive network attempts.
@@ -118,6 +151,8 @@ def _is_network_error(exc: subprocess.CalledProcessError) -> bool:
         "no route to host",
         "fatal: unable to access",
         "ssh: connect",
+        "http 429",
+        "rpc failed",
     )
     return any(k in stderr for k in keywords)
 
@@ -178,15 +213,12 @@ def open_conflict_pr(
     merge_base_sha: str,
     conflict_commit: str,
     conflicted_files: list[str],
+    title: str,
 ) -> str:
     compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{merge_base_sha[:12]}...{conflict_commit[:12]}"
     file_list = "\n".join(f"- `{f}`" for f in conflicted_files)
-    title = (
-        f"ROCgdb master → amd-staging conflict: "
-        f"{merge_base_sha[:12]}..{conflict_commit[:12]}"
-    )
     body = (
-        f"## ROCgdb master → amd-staging merge conflict\n\n"
+        f"## ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} merge conflict\n\n"
         f"**Commits being merged:** [{merge_base_sha[:12]}...{conflict_commit[:12]}]({compare_url})\n\n"
         f"**Conflicted files:**\n{file_list}\n\n"
         f"Please resolve the conflicts, remove the `{CI_SKIP_LABEL}` label, "
@@ -204,7 +236,7 @@ def open_conflict_pr(
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--head",
             branch,
             "--title",
@@ -232,7 +264,7 @@ def find_open_conflict_pr() -> str | None:
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--state",
             "open",
             "--label",
@@ -247,24 +279,21 @@ def find_open_conflict_pr() -> str | None:
     return url if url else None
 
 
-def open_ff_pr(
+def open_conflict_free_pr(
     branch: str,
     first_commit: str,
     last_commit: str,
+    title: str,
 ) -> str:
     compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{first_commit[:12]}...{last_commit[:12]}"
-    title = (
-        f"ROCgdb master → amd-staging fast-forward: "
-        f"{first_commit[:12]}..{last_commit[:12]}"
-    )
     body = (
-        f"## ROCgdb master → amd-staging fast-forward merge\n\n"
+        f"## ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free merge\n\n"
         f"**Commits being merged:** [{first_commit[:12]}...{last_commit[:12]}]({compare_url})\n\n"
         f"This PR was opened automatically by the automerge workflow. "
         f"Please validate CI, then merge."
     )
 
-    _ensure_label(FF_LABEL, "0075ca")
+    _ensure_label(CONFLICT_FREE_LABEL, "0075ca")
 
     result = run(
         [
@@ -274,7 +303,7 @@ def open_ff_pr(
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--head",
             branch,
             "--title",
@@ -282,16 +311,16 @@ def open_ff_pr(
             "--body",
             body,
             "--label",
-            FF_LABEL,
+            CONFLICT_FREE_LABEL,
         ]
     )
     pr_url = result.stdout.strip()
-    print(f"Fast-forward PR opened: {pr_url}")
+    print(f"Conflict-free PR opened: {pr_url}")
     return pr_url
 
 
-def find_open_ff_pr() -> str | None:
-    """Return the URL of an open fast-forward PR if one exists, else None."""
+def find_open_conflict_free_pr() -> str | None:
+    """Return the URL of an open conflict-free PR if one exists, else None."""
     result = run(
         [
             "gh",
@@ -300,11 +329,11 @@ def find_open_ff_pr() -> str | None:
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--state",
             "open",
             "--label",
-            FF_LABEL,
+            CONFLICT_FREE_LABEL,
             "--json",
             "url",
             "--jq",
@@ -320,11 +349,18 @@ def find_open_ff_pr() -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def push_master_mirror(repo: Path) -> None:
-    """Fast-forward origin/master to match sourceware/master."""
-    print("Fast-forwarding origin/master to sourceware/master…")
+def push_upstream_mirror(repo: Path) -> None:
+    """Fast-forward origin/UPSTREAM_BRANCH to match SOURCEWARE_REMOTE/UPSTREAM_BRANCH."""
+    print(
+        f"Fast-forwarding origin/{UPSTREAM_BRANCH} to {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}…"
+    )
     run_net(
-        ["git", "push", "origin", "sourceware/master:refs/heads/master"],
+        [
+            "git",
+            "push",
+            "origin",
+            f"{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}:refs/heads/{UPSTREAM_BRANCH}",
+        ],
         cwd=repo,
     )
 
@@ -334,10 +370,10 @@ def probe_clean_prefix(
     commits: list[str],
 ) -> tuple[str | None, str | None]:
     """
-    Walk commits oldest-to-newest on a throwaway branch off origin/amd-staging.
+    Walk commits oldest-to-newest on a throwaway branch off origin/TARGET_BRANCH.
     Returns (last_clean_commit, first_conflict_commit).
     """
-    run(["git", "checkout", "-B", "probe", "origin/amd-staging"], cwd=repo)
+    run(["git", "checkout", "-B", "probe", f"origin/{TARGET_BRANCH}"], cwd=repo)
 
     last_clean = None
     first_conflict = None
@@ -346,49 +382,55 @@ def probe_clean_prefix(
         for commit in commits:
             result = run(["git", "merge", "--no-edit", commit], cwd=repo, check=False)
             if result.returncode != 0:
-                run(["git", "merge", "--abort"], cwd=repo)
+                run(["git", "merge", "--abort"], cwd=repo, check=False)
                 first_conflict = commit
                 break
             last_clean = commit
     finally:
-        run(["git", "checkout", "--detach", "HEAD"], cwd=repo)
-        run(["git", "branch", "-D", "probe"], cwd=repo)
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo, check=False)
+        run(["git", "branch", "-D", "probe"], cwd=repo, check=False)
 
     return last_clean, first_conflict
 
 
 def main() -> None:
-    WORK_DIR.mkdir(parents=True, exist_ok=True)
-    repo = WORK_DIR / "binutils-gdb"
-
-    try:
-        # ------------------------------------------------------------------ #
-        # 1. Clone or reuse.                                                   #
-        # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ #
+    # 1. Clone or reuse.                                                   #
+    # ------------------------------------------------------------------ #
+    if _args.repo:
+        repo = Path(_args.repo).resolve()
+        if not (repo / ".git").exists():
+            print(f"Error: --repo '{repo}' is not a git repository.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Using existing repo at {repo}…")
+    else:
+        WORK_DIR.mkdir(parents=True, exist_ok=True)
+        repo = WORK_DIR / "binutils-gdb"
         if (repo / ".git").exists():
             print(f"Reusing existing clone at {repo}…")
         else:
             print(f"Cloning {ROCGDB_REPO}…")
-            run_net(["git", "clone", ROCGDB_ORIGIN_URL, str(repo)])
+            run_net(
+                ["git", "clone", "--filter=blob:none", ROCGDB_ORIGIN_URL, str(repo)]
+            )
+
+    try:
 
         remotes = run(["git", "remote"], cwd=repo).stdout.split()
-        if "sourceware" not in remotes:
-            run(["git", "remote", "add", "sourceware", SOURCEWARE_URL], cwd=repo)
+        if SOURCEWARE_REMOTE not in remotes:
+            run(["git", "remote", "add", SOURCEWARE_REMOTE, SOURCEWARE_URL], cwd=repo)
 
         # ------------------------------------------------------------------ #
-        # 2. Fetch sourceware/master and origin/amd-staging.                  #
+        # 2. Fetch sourceware/UPSTREAM_BRANCH and update mirror.            #
         # ------------------------------------------------------------------ #
-        print("Fetching sourceware/master…")
-        run_net(["git", "fetch", "sourceware", "master"], cwd=repo)
-
-        print("Fetching origin/amd-staging…")
-        run_net(["git", "fetch", "origin", "amd-staging"], cwd=repo)
+        print(f"Fetching {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}…")
+        run_net(["git", "fetch", SOURCEWARE_REMOTE, UPSTREAM_BRANCH], cwd=repo)
 
         if not DRY_RUN:
-            push_master_mirror(repo)
+            push_upstream_mirror(repo)
 
         # ------------------------------------------------------------------ #
-        # 3. Skip if a conflict or fast-forward PR is already open.           #
+        # 3. Skip if a conflict or conflict-free PR is already open.          #
         # ------------------------------------------------------------------ #
         existing_conflict_pr = find_open_conflict_pr()
         if existing_conflict_pr:
@@ -398,19 +440,30 @@ def main() -> None:
             )
             return
 
-        existing_ff_pr = find_open_ff_pr()
-        if existing_ff_pr:
+        existing_conflict_free_pr = find_open_conflict_free_pr()
+        if existing_conflict_free_pr:
             print(
-                f"Open fast-forward PR found: {existing_ff_pr}\n"
+                f"Open conflict-free PR found: {existing_conflict_free_pr}\n"
                 "Skipping merge — wait for the PR to be merged first."
             )
             return
 
         # ------------------------------------------------------------------ #
-        # 4. Determine the commit range to merge.                             #
+        # 4. Fetch origin/TARGET_BRANCH (only needed for merge work).        #
+        # ------------------------------------------------------------------ #
+        print(f"Fetching origin/{TARGET_BRANCH}…")
+        run_net(["git", "fetch", "origin", TARGET_BRANCH], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 5. Determine the commit range to merge.                             #
         # ------------------------------------------------------------------ #
         merge_base_sha = run(
-            ["git", "merge-base", "origin/amd-staging", "sourceware/master"],
+            [
+                "git",
+                "merge-base",
+                f"origin/{TARGET_BRANCH}",
+                f"{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}",
+            ],
             cwd=repo,
         ).stdout.strip()
 
@@ -420,14 +473,14 @@ def main() -> None:
                 "log",
                 "--format=%H",
                 "--reverse",
-                f"{merge_base_sha}..sourceware/master",
+                f"{merge_base_sha}..{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}",
             ],
             cwd=repo,
         ).stdout.strip()
 
         if not log_out:
             print(
-                "amd-staging is already up to date with sourceware/master. Nothing to do."
+                f"{TARGET_BRANCH} is already up to date with {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}. Nothing to do."
             )
             return
 
@@ -438,64 +491,96 @@ def main() -> None:
         )
 
         # ------------------------------------------------------------------ #
-        # 5. Set up local amd-staging branch.                                 #
+        # 6. Set up local target branch (skipped in dry-run; probe uses the  #
+        #    remote ref directly and we have no local branch to return to).   #
         # ------------------------------------------------------------------ #
         if not DRY_RUN:
             run(
-                ["git", "checkout", "-B", "amd-staging", "origin/amd-staging"],
+                ["git", "checkout", "-B", TARGET_BRANCH, f"origin/{TARGET_BRANCH}"],
                 cwd=repo,
             )
 
         # ------------------------------------------------------------------ #
-        # 6. Probe for the largest clean prefix.                              #
+        # 7. Probe for the largest clean prefix.                              #
         # ------------------------------------------------------------------ #
         print("Probing for clean merge prefix…")
         last_clean, first_conflict = probe_clean_prefix(repo, commits)
 
         # Probe leaves the repo on detached HEAD; return to the local branch.
         if not DRY_RUN:
-            run(["git", "checkout", "amd-staging"], cwd=repo)
+            run(["git", "checkout", TARGET_BRANCH], cwd=repo)
 
         # ------------------------------------------------------------------ #
-        # 7a. All commits apply cleanly → open a fast-forward PR.            #
+        # 7a. All commits apply cleanly → open a conflict-free PR.           #
         # ------------------------------------------------------------------ #
         if first_conflict is None:
             print(f"All {len(commits)} commit(s) merge cleanly.")
-            ff_branch = (
-                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            conflict_free_branch = f"{CONFLICT_FREE_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            conflict_free_title = (
+                f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free: "
+                f"{merge_base_sha[:12]}..{commits[-1][:12]}"
             )
             if DRY_RUN:
-                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+                print(
+                    f"[DRY RUN] Would open conflict-free PR:\n"
+                    f"  Branch : {conflict_free_branch}\n"
+                    f"  Commits: {merge_base_sha[:12]}..{commits[-1][:12]}"
+                    f" ({len(commits)} commit(s))\n"
+                    f"  Title  : {conflict_free_title}"
+                )
             else:
-                run(["git", "checkout", "-B", ff_branch], cwd=repo)
-                run(["git", "merge", "--no-edit", commits[-1]], cwd=repo)
-                run_net(["git", "push", "origin", ff_branch], cwd=repo)
-                open_ff_pr(
-                    branch=ff_branch,
+                run_net(
+                    [
+                        "git",
+                        "push",
+                        "origin",
+                        f"{commits[-1]}:refs/heads/{conflict_free_branch}",
+                    ],
+                    cwd=repo,
+                )
+                open_conflict_free_pr(
+                    branch=conflict_free_branch,
                     first_commit=merge_base_sha,
                     last_commit=commits[-1],
+                    title=conflict_free_title,
                 )
             return
 
         # ------------------------------------------------------------------ #
-        # 7b. Partial clean prefix → open a fast-forward PR for clean range. #
+        # 7b. Partial clean prefix → open a conflict-free PR for clean range.#
         # ------------------------------------------------------------------ #
         if last_clean is not None:
-            print(f"Clean prefix ends at {last_clean[:12]}. Opening fast-forward PR…")
-            ff_branch = (
-                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            print(f"Clean prefix ends at {last_clean[:12]}. Opening conflict-free PR…")
+            clean_count = commits.index(last_clean) + 1
+            conflict_free_branch = f"{CONFLICT_FREE_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            conflict_free_title = (
+                f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free: "
+                f"{merge_base_sha[:12]}..{last_clean[:12]}"
             )
             if DRY_RUN:
-                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
-            else:
-                run(["git", "checkout", "-B", ff_branch], cwd=repo)
-                run(["git", "merge", "--no-edit", last_clean], cwd=repo)
-                run_net(["git", "push", "origin", ff_branch], cwd=repo)
-                open_ff_pr(
-                    branch=ff_branch,
-                    first_commit=merge_base_sha,
-                    last_commit=last_clean,
+                print(
+                    f"[DRY RUN] Would open conflict-free PR:\n"
+                    f"  Branch : {conflict_free_branch}\n"
+                    f"  Commits: {merge_base_sha[:12]}..{last_clean[:12]}"
+                    f" ({clean_count} commit(s))\n"
+                    f"  Title  : {conflict_free_title}"
                 )
+                return
+            run_net(
+                [
+                    "git",
+                    "push",
+                    "origin",
+                    f"{last_clean}:refs/heads/{conflict_free_branch}",
+                ],
+                cwd=repo,
+            )
+            open_conflict_free_pr(
+                branch=conflict_free_branch,
+                first_commit=merge_base_sha,
+                last_commit=last_clean,
+                title=conflict_free_title,
+            )
             return
         else:
             print("No clean commits to merge; first commit already conflicts.")
@@ -513,25 +598,47 @@ def main() -> None:
         ).stdout.strip()
         print(f"\nConflict commit: {conflict_info}")
 
+        # Probe the conflicted files by attempting the merge on a scratch branch.
+        run(
+            ["git", "checkout", "-B", "probe-conflict", f"origin/{TARGET_BRANCH}"],
+            cwd=repo,
+        )
+        run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
+        conflicted_files = (
+            run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
+            .stdout.strip()
+            .splitlines()
+        )
+        run(["git", "merge", "--abort"], cwd=repo, check=False)
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo, check=False)
+        run(["git", "branch", "-D", "probe-conflict"], cwd=repo, check=False)
+
+        conflict_title = (
+            f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict: "
+            f"{merge_base_sha[:12]}..{first_conflict[:12]}"
+        )
+
         if DRY_RUN:
-            print(f"[DRY RUN] would push {conflict_branch} and open conflict PR.")
+            files_str = "\n".join(f"    {f}" for f in conflicted_files)
+            print(
+                f"[DRY RUN] Would open conflict PR:\n"
+                f"  Branch            : {conflict_branch}\n"
+                f"  Conflicting commit: {conflict_info}\n"
+                f"  Conflicted files  :\n{files_str}\n"
+                f"  Title             : {conflict_title}"
+            )
         else:
-            # Checkout a fresh conflict branch from the current amd-staging state.
+            # Checkout a fresh conflict branch from the current target branch state.
             run(["git", "checkout", "-B", conflict_branch], cwd=repo)
             run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
 
-            conflicted_files = (
-                run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
-                .stdout.strip()
-                .splitlines()
-            )
             print("Conflicted files:")
             for f in conflicted_files:
                 print(f"  {f}")
 
             # Stage and commit the conflict markers so the branch carries a diff
             # that gh pr create can open (the branch would otherwise be identical
-            # to amd-staging and gh would reject it with "no commits between...").
+            # to the target branch and gh would reject it with "no commits between...").
             run(["git", "add", "-A"], cwd=repo)
             run(
                 [
@@ -539,7 +646,7 @@ def main() -> None:
                     "commit",
                     "--no-verify",
                     "-m",
-                    f"Merge {first_conflict[:12]} into amd-staging (unresolved conflicts)",
+                    f"Merge {first_conflict[:12]} into {TARGET_BRANCH} (unresolved conflicts)",
                 ],
                 cwd=repo,
             )
@@ -550,6 +657,7 @@ def main() -> None:
                 merge_base_sha=merge_base_sha,
                 conflict_commit=first_conflict,
                 conflicted_files=conflicted_files,
+                title=conflict_title,
             )
 
     except ConnectivityError:

--- a/.github/scripts/test_automerge.py
+++ b/.github/scripts/test_automerge.py
@@ -80,7 +80,9 @@ class TestRun(unittest.TestCase):
 class TestRunNet(unittest.TestCase):
     @patch("time.sleep")
     def test_retries_on_network_error_then_succeeds(self, mock_sleep):
-        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+        network_err = subprocess.CalledProcessError(
+            128, ["git"], "", "could not resolve host"
+        )
         ok = _completed()
 
         call_count = 0
@@ -99,7 +101,9 @@ class TestRunNet(unittest.TestCase):
 
     @patch("time.sleep")
     def test_raises_connectivity_error_after_all_retries(self, mock_sleep):
-        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+        network_err = subprocess.CalledProcessError(
+            128, ["git"], "", "could not resolve host"
+        )
 
         with patch.object(am, "run", side_effect=network_err):
             with self.assertRaises(am.ConnectivityError):
@@ -123,7 +127,11 @@ class TestRunNet(unittest.TestCase):
 
 class TestFindOpenPr(unittest.TestCase):
     def test_returns_url_when_present(self):
-        with patch.object(am, "run", return_value=_completed(stdout="https://github.com/ROCm/ROCgdb/pull/42\n")):
+        with patch.object(
+            am,
+            "run",
+            return_value=_completed(stdout="https://github.com/ROCm/ROCgdb/pull/42\n"),
+        ):
             url = am.find_open_conflict_pr()
         self.assertEqual(url, "https://github.com/ROCm/ROCgdb/pull/42")
 
@@ -233,18 +241,22 @@ class TestEarlyExitGate(unittest.TestCase):
         return patches
 
     def test_skips_when_conflict_pr_open(self):
-        patches = self._patch_main_deps(conflict_pr="https://github.com/ROCm/ROCgdb/pull/1")
+        patches = self._patch_main_deps(
+            conflict_pr="https://github.com/ROCm/ROCgdb/pull/1"
+        )
         # Also patch repo/.git exists check so clone is skipped.
-        with patch("pathlib.Path.exists", return_value=True), \
-             patches[0], patches[1], patches[2], patches[3], patches[4]:
+        with patch("pathlib.Path.exists", return_value=True), patches[0], patches[
+            1
+        ], patches[2], patches[3], patches[4]:
             with patch.object(am, "probe_clean_prefix") as mock_probe:
                 am.main()
                 mock_probe.assert_not_called()
 
     def test_skips_when_ff_pr_open(self):
         patches = self._patch_main_deps(ff_pr="https://github.com/ROCm/ROCgdb/pull/2")
-        with patch("pathlib.Path.exists", return_value=True), \
-             patches[0], patches[1], patches[2], patches[3], patches[4]:
+        with patch("pathlib.Path.exists", return_value=True), patches[0], patches[
+            1
+        ], patches[2], patches[3], patches[4]:
             with patch.object(am, "probe_clean_prefix") as mock_probe:
                 am.main()
                 mock_probe.assert_not_called()
@@ -287,17 +299,25 @@ class TestDryRun(unittest.TestCase):
             run_net_calls.append(list(cmd))
             return _completed()
 
-        with patch("pathlib.Path.mkdir"), \
-             patch("pathlib.Path.exists", return_value=True), \
-             patch.object(am, "run", side_effect=fake_run), \
-             patch.object(am, "run_net", side_effect=fake_run_net), \
-             patch.object(am, "find_open_conflict_pr", return_value=None), \
-             patch.object(am, "find_open_ff_pr", return_value=None), \
-             patch.object(am, "probe_clean_prefix", return_value=probe_result), \
-             patch.object(am, "open_ff_pr") as mock_ff_pr, \
-             patch.object(am, "open_conflict_pr") as mock_conflict_pr, \
-             patch.object(am, "push_master_mirror") as mock_mirror, \
-             patch.object(am, "DRY_RUN", True):
+        with patch("pathlib.Path.mkdir"), patch(
+            "pathlib.Path.exists", return_value=True
+        ), patch.object(am, "run", side_effect=fake_run), patch.object(
+            am, "run_net", side_effect=fake_run_net
+        ), patch.object(
+            am, "find_open_conflict_pr", return_value=None
+        ), patch.object(
+            am, "find_open_ff_pr", return_value=None
+        ), patch.object(
+            am, "probe_clean_prefix", return_value=probe_result
+        ), patch.object(
+            am, "open_ff_pr"
+        ) as mock_ff_pr, patch.object(
+            am, "open_conflict_pr"
+        ) as mock_conflict_pr, patch.object(
+            am, "push_master_mirror"
+        ) as mock_mirror, patch.object(
+            am, "DRY_RUN", True
+        ):
             am.main()
 
         return run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror

--- a/.github/scripts/test_automerge.py
+++ b/.github/scripts/test_automerge.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for automerge.py."""
+
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test without triggering _parse_args() or WORK_DIR
+# resolution (both run at import time via module-level code).
+# ---------------------------------------------------------------------------
+
+import importlib
+import importlib.util
+import os
+
+
+def _load_automerge():
+    """Load automerge as a module, neutralising its module-level side-effects."""
+    spec = importlib.util.spec_from_file_location(
+        "automerge",
+        Path(__file__).parent / "automerge.py",
+    )
+    # Patch sys.argv so argparse doesn't see pytest/unittest args.
+    with patch("sys.argv", ["automerge.py"]):
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+am = _load_automerge()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    r = MagicMock(spec=subprocess.CompletedProcess)
+    r.returncode = returncode
+    r.stdout = stdout
+    r.stderr = stderr
+    return r
+
+
+# ---------------------------------------------------------------------------
+# run() / run_net()
+# ---------------------------------------------------------------------------
+
+
+class TestRun(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_run_raises_on_nonzero_with_check(self, mock_subproc):
+        mock_subproc.return_value = _completed(returncode=1, stderr="oops")
+        with self.assertRaises(subprocess.CalledProcessError):
+            am.run(["false"])
+
+    @patch("subprocess.run")
+    def test_run_returns_result_when_check_false(self, mock_subproc):
+        mock_subproc.return_value = _completed(returncode=1, stderr="oops")
+        result = am.run(["false"], check=False)
+        self.assertEqual(result.returncode, 1)
+
+    @patch("subprocess.run")
+    def test_run_redacts_matching_args(self, mock_subproc):
+        mock_subproc.return_value = _completed()
+        with patch("builtins.print") as mock_print:
+            am.run(["git", "push", "https://token@host/repo"], redact=["token"])
+        printed = " ".join(str(a) for a in mock_print.call_args_list)
+        self.assertNotIn("token", printed)
+        self.assertIn("<redacted>", printed)
+
+
+class TestRunNet(unittest.TestCase):
+    @patch("time.sleep")
+    def test_retries_on_network_error_then_succeeds(self, mock_sleep):
+        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+        ok = _completed()
+
+        call_count = 0
+
+        def fake_run(cmd, cwd=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise network_err
+            return ok
+
+        with patch.object(am, "run", side_effect=fake_run):
+            result = am.run_net(["git", "fetch"])
+        self.assertEqual(call_count, 2)
+        mock_sleep.assert_called_once()
+
+    @patch("time.sleep")
+    def test_raises_connectivity_error_after_all_retries(self, mock_sleep):
+        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+
+        with patch.object(am, "run", side_effect=network_err):
+            with self.assertRaises(am.ConnectivityError):
+                am.run_net(["git", "fetch"])
+
+        # sleep called once per inter-attempt gap
+        self.assertEqual(mock_sleep.call_count, len(am.RETRY_DELAYS))
+
+    def test_reraises_non_network_error_immediately(self):
+        non_net_err = subprocess.CalledProcessError(1, ["git"], "", "permission denied")
+
+        with patch.object(am, "run", side_effect=non_net_err):
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.run_net(["git", "fetch"])
+
+
+# ---------------------------------------------------------------------------
+# find_open_conflict_pr / find_open_ff_pr
+# ---------------------------------------------------------------------------
+
+
+class TestFindOpenPr(unittest.TestCase):
+    def test_returns_url_when_present(self):
+        with patch.object(am, "run", return_value=_completed(stdout="https://github.com/ROCm/ROCgdb/pull/42\n")):
+            url = am.find_open_conflict_pr()
+        self.assertEqual(url, "https://github.com/ROCm/ROCgdb/pull/42")
+
+    def test_returns_none_when_no_pr(self):
+        with patch.object(am, "run", return_value=_completed(stdout="")):
+            url = am.find_open_conflict_pr()
+        self.assertIsNone(url)
+
+    def test_raises_on_gh_cli_failure(self):
+        with patch.object(
+            am,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, ["gh"], "", "auth error"),
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.find_open_conflict_pr()
+
+    def test_ff_returns_none_when_no_pr(self):
+        with patch.object(am, "run", return_value=_completed(stdout="")):
+            url = am.find_open_ff_pr()
+        self.assertIsNone(url)
+
+
+# ---------------------------------------------------------------------------
+# probe_clean_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCleanPrefix(unittest.TestCase):
+    def _run_side_effect(self, outcomes):
+        """
+        outcomes: list of returncode ints, one per git-merge call.
+        All other run() calls (checkout, branch -D, merge --abort) succeed.
+        """
+        merge_returncodes = iter(outcomes)
+
+        def fake_run(cmd, cwd=None, check=True, **kwargs):
+            if cmd[:2] == ["git", "merge"] and "--abort" not in cmd:
+                rc = next(merge_returncodes)
+                result = _completed(returncode=rc)
+                if check and rc != 0:
+                    raise subprocess.CalledProcessError(rc, cmd, "", "conflict")
+                return result
+            return _completed()
+
+        return fake_run
+
+    def test_all_clean(self):
+        commits = ["aaa", "bbb", "ccc"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([0, 0, 0])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertEqual(last_clean, "ccc")
+        self.assertIsNone(first_conflict)
+
+    def test_first_conflicts(self):
+        commits = ["aaa", "bbb"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([1])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertIsNone(last_clean)
+        self.assertEqual(first_conflict, "aaa")
+
+    def test_partial_clean_prefix(self):
+        commits = ["aaa", "bbb", "ccc"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([0, 1])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertEqual(last_clean, "aaa")
+        self.assertEqual(first_conflict, "bbb")
+
+    def test_cleanup_runs_even_when_abort_raises(self):
+        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort raises."""
+        cleanup_calls = []
+
+        def fake_subproc(cmd, **kwargs):
+            if cmd[:2] == ["git", "merge"] and "--abort" not in cmd:
+                return _completed(returncode=1, stderr="conflict")
+            if "--abort" in cmd:
+                # Simulate merge --abort failing (e.g. no merge in progress).
+                return _completed(returncode=1, stderr="cannot abort")
+            if "--detach" in cmd or "-D" in cmd:
+                cleanup_calls.append(list(cmd))
+            return _completed()
+
+        with patch("subprocess.run", side_effect=fake_subproc):
+            # merge --abort returns non-zero; run() with check=True will raise.
+            # probe_clean_prefix calls merge --abort with check=True, so it raises.
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.probe_clean_prefix(Path("/repo"), ["aaa"])
+
+        self.assertEqual(len(cleanup_calls), 2)
+
+
+# ---------------------------------------------------------------------------
+# Early-exit gate (main integration slice — no actual git/gh calls)
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyExitGate(unittest.TestCase):
+    def _patch_main_deps(self, conflict_pr=None, ff_pr=None):
+        """Patch just enough of main() to test the gate logic."""
+        patches = [
+            patch("pathlib.Path.mkdir"),
+            patch.object(am, "run_net", return_value=_completed()),
+            patch.object(am, "run", return_value=_completed(stdout="")),
+            patch.object(am, "find_open_conflict_pr", return_value=conflict_pr),
+            patch.object(am, "find_open_ff_pr", return_value=ff_pr),
+        ]
+        return patches
+
+    def test_skips_when_conflict_pr_open(self):
+        patches = self._patch_main_deps(conflict_pr="https://github.com/ROCm/ROCgdb/pull/1")
+        # Also patch repo/.git exists check so clone is skipped.
+        with patch("pathlib.Path.exists", return_value=True), \
+             patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patch.object(am, "probe_clean_prefix") as mock_probe:
+                am.main()
+                mock_probe.assert_not_called()
+
+    def test_skips_when_ff_pr_open(self):
+        patches = self._patch_main_deps(ff_pr="https://github.com/ROCm/ROCgdb/pull/2")
+        with patch("pathlib.Path.exists", return_value=True), \
+             patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patch.object(am, "probe_clean_prefix") as mock_probe:
+                am.main()
+                mock_probe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run end-to-end flow
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun(unittest.TestCase):
+    """
+    Exercises the full main() flow with --dry-run set, verifying that
+    probe_clean_prefix runs but no push or PR-creation calls are made.
+    """
+
+    def _run_dry(self, probe_result):
+        """
+        Run main() with DRY_RUN=True, returning the set of run_net call args.
+        probe_result: (last_clean, first_conflict) tuple returned by probe.
+        """
+        run_net_calls = []
+
+        def fake_run(cmd, cwd=None, check=True, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            # Return a plausible stdout for commands that produce output.
+            if "remote" in cmd and cmd[-1] == "remote":
+                return _completed(stdout="origin\nsourceware\n")
+            if "merge-base" in cmd:
+                return _completed(stdout="base0000000000000000000000000000000000000000")
+            if "log" in cmd and "--format=%H" in cmd:
+                return _completed(stdout="aaa\nbbb\nccc")
+            if "log" in cmd and "--format=%H %s" in cmd:
+                return _completed(stdout="aaa subject (Author <a@b.com>)")
+            if "diff" in cmd:
+                return _completed(stdout="file.c\n")
+            return _completed()
+
+        def fake_run_net(cmd, cwd=None):
+            run_net_calls.append(list(cmd))
+            return _completed()
+
+        with patch("pathlib.Path.mkdir"), \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch.object(am, "run", side_effect=fake_run), \
+             patch.object(am, "run_net", side_effect=fake_run_net), \
+             patch.object(am, "find_open_conflict_pr", return_value=None), \
+             patch.object(am, "find_open_ff_pr", return_value=None), \
+             patch.object(am, "probe_clean_prefix", return_value=probe_result), \
+             patch.object(am, "open_ff_pr") as mock_ff_pr, \
+             patch.object(am, "open_conflict_pr") as mock_conflict_pr, \
+             patch.object(am, "push_master_mirror") as mock_mirror, \
+             patch.object(am, "DRY_RUN", True):
+            am.main()
+
+        return run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror
+
+    def test_dry_run_all_clean_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=("ccc", None)
+        )
+        # Only the two fetches should have gone out, no push.
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_ff_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+    def test_dry_run_conflict_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=(None, "aaa")
+        )
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_conflict_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+    def test_dry_run_partial_prefix_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=("aaa", "bbb")
+        )
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_ff_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_automerge.py
+++ b/.github/scripts/test_automerge.py
@@ -19,6 +19,12 @@ import importlib
 import importlib.util
 import os
 
+_TEST_ENV = {
+    "GITHUB_REPOSITORY": "ROCm/ROCgdb",
+    "AUTOMERGE_TARGET_BRANCH": "amd-staging",
+    "AUTOMERGE_UPSTREAM_BRANCH": "master",
+}
+
 
 def _load_automerge():
     """Load automerge as a module, neutralising its module-level side-effects."""
@@ -27,7 +33,8 @@ def _load_automerge():
         Path(__file__).parent / "automerge.py",
     )
     # Patch sys.argv so argparse doesn't see pytest/unittest args.
-    with patch("sys.argv", ["automerge.py"]):
+    # Inject required env vars so module-level validation doesn't call sys.exit.
+    with patch("sys.argv", ["automerge.py"]), patch.dict(os.environ, _TEST_ENV):
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
     return mod
@@ -121,7 +128,7 @@ class TestRunNet(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# find_open_conflict_pr / find_open_ff_pr
+# find_open_conflict_pr / find_open_conflict_free_pr
 # ---------------------------------------------------------------------------
 
 
@@ -151,7 +158,7 @@ class TestFindOpenPr(unittest.TestCase):
 
     def test_ff_returns_none_when_no_pr(self):
         with patch.object(am, "run", return_value=_completed(stdout="")):
-            url = am.find_open_ff_pr()
+            url = am.find_open_conflict_free_pr()
         self.assertIsNone(url)
 
 
@@ -200,8 +207,8 @@ class TestProbeCleanPrefix(unittest.TestCase):
         self.assertEqual(last_clean, "aaa")
         self.assertEqual(first_conflict, "bbb")
 
-    def test_cleanup_runs_even_when_abort_raises(self):
-        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort raises."""
+    def test_cleanup_runs_even_when_abort_fails(self):
+        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort fails."""
         cleanup_calls = []
 
         def fake_subproc(cmd, **kwargs):
@@ -209,17 +216,17 @@ class TestProbeCleanPrefix(unittest.TestCase):
                 return _completed(returncode=1, stderr="conflict")
             if "--abort" in cmd:
                 # Simulate merge --abort failing (e.g. no merge in progress).
+                # probe_clean_prefix calls this with check=False so it doesn't raise.
                 return _completed(returncode=1, stderr="cannot abort")
             if "--detach" in cmd or "-D" in cmd:
                 cleanup_calls.append(list(cmd))
             return _completed()
 
         with patch("subprocess.run", side_effect=fake_subproc):
-            # merge --abort returns non-zero; run() with check=True will raise.
-            # probe_clean_prefix calls merge --abort with check=True, so it raises.
-            with self.assertRaises(subprocess.CalledProcessError):
-                am.probe_clean_prefix(Path("/repo"), ["aaa"])
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), ["aaa"])
 
+        self.assertIsNone(last_clean)
+        self.assertEqual(first_conflict, "aaa")
         self.assertEqual(len(cleanup_calls), 2)
 
 
@@ -236,7 +243,7 @@ class TestEarlyExitGate(unittest.TestCase):
             patch.object(am, "run_net", return_value=_completed()),
             patch.object(am, "run", return_value=_completed(stdout="")),
             patch.object(am, "find_open_conflict_pr", return_value=conflict_pr),
-            patch.object(am, "find_open_ff_pr", return_value=ff_pr),
+            patch.object(am, "find_open_conflict_free_pr", return_value=ff_pr),
         ]
         return patches
 
@@ -306,15 +313,15 @@ class TestDryRun(unittest.TestCase):
         ), patch.object(
             am, "find_open_conflict_pr", return_value=None
         ), patch.object(
-            am, "find_open_ff_pr", return_value=None
+            am, "find_open_conflict_free_pr", return_value=None
         ), patch.object(
             am, "probe_clean_prefix", return_value=probe_result
         ), patch.object(
-            am, "open_ff_pr"
+            am, "open_conflict_free_pr"
         ) as mock_ff_pr, patch.object(
             am, "open_conflict_pr"
         ) as mock_conflict_pr, patch.object(
-            am, "push_master_mirror"
+            am, "push_upstream_mirror"
         ) as mock_mirror, patch.object(
             am, "DRY_RUN", True
         ):
@@ -348,6 +355,7 @@ class TestDryRun(unittest.TestCase):
         push_calls = [c for c in run_net_calls if "push" in c]
         self.assertEqual(push_calls, [])
         mock_ff_pr.assert_not_called()
+        mock_conflict_pr.assert_not_called()
         mock_mirror.assert_not_called()
 
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,11 @@ on:
   schedule: # runs every 6 hours
     - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (fetch and probe, but skip pushes and PR creation)'
+        type: boolean
+        default: false
   pull_request:
     types: [closed]
     branches: [amd-staging]
@@ -27,6 +32,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WORKSPACE: ${{ github.workspace }}
+      AUTOMERGE_TARGET_BRANCH: ${{ vars.AUTOMERGE_TARGET_BRANCH }}
+      AUTOMERGE_UPSTREAM_BRANCH: ${{ vars.AUTOMERGE_UPSTREAM_BRANCH }}
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -37,4 +44,5 @@ jobs:
           git config --global credential.helper "!gh auth git-credential"
       - name: Trigger Automerge Job
         run: |
-          python3 .github/scripts/automerge.py
+          python3 .github/scripts/automerge.py \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,40 @@
+name: GDB Automerge
+on:
+  schedule: # runs every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [amd-staging]
+
+concurrency:
+  group: gdb-automerge
+  cancel-in-progress: false
+
+jobs:
+  automerge-to-staging:
+    runs-on: ubuntu-latest
+    if: false
+    # Remove the above and uncomment below to activate:
+    # if: |
+    #   github.event_name != 'pull_request' ||
+    #   (github.event.pull_request.merged == true &&
+    #    (contains(github.event.pull_request.labels.*.name, 'merge-testing') ||
+    #     contains(github.event.pull_request.labels.*.name, 'merge-conflict')))
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      WORKSPACE: ${{ github.workspace }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - name: Configure git identity and credentials
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global credential.helper "!gh auth git-credential"
+      - name: Trigger Automerge Job
+        run: |
+          python3 .github/scripts/automerge.py

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,9 +8,6 @@ on:
         description: 'Dry run (fetch and probe, but skip pushes and PR creation)'
         type: boolean
         default: false
-  pull_request:
-    types: [closed]
-    branches: [amd-staging]
 
 concurrency:
   group: gdb-automerge
@@ -19,13 +16,6 @@ concurrency:
 jobs:
   automerge-to-staging:
     runs-on: ubuntu-latest
-    if: false
-    # Remove the above and uncomment below to activate:
-    # if: |
-    #   github.event_name != 'pull_request' ||
-    #   (github.event.pull_request.merged == true &&
-    #    (contains(github.event.pull_request.labels.*.name, 'merge-testing') ||
-    #     contains(github.event.pull_request.labels.*.name, 'merge-conflict')))
     permissions:
       contents: write
       pull-requests: write
@@ -45,4 +35,5 @@ jobs:
       - name: Trigger Automerge Job
         run: |
           python3 .github/scripts/automerge.py \
+            --repo "$WORKSPACE" \
             ${{ inputs.dry_run == true && '--dry-run' || '' }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,116 @@
+name: Nightly ROCgdb Build
+
+on:
+  schedule:
+    - cron: '7 2 * * *'  # 2:07 AM UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'ROCgdb branch/ref to build (defaults to master)'
+        required: false
+        default: 'master'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-rocgdb-${{ inputs.branch || 'master' }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve TheRock references
+    runs-on: ubuntu-24.04
+    outputs:
+      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
+      build_image: ${{ steps.read.outputs.build_image }}
+      build_runs_on: ${{ steps.runner.outputs.build_runs_on }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read TheRock dependency pins
+        id: read
+        run: python3 .github/scripts/config.py therock_commit_ref build_image
+
+      - name: Select build runner
+        id: runner
+        run: python3 .github/scripts/select_runner.py build_runs_on
+
+  nightly-rocgdb-build-linux:
+    name: Nightly ROCgdb Build Linux
+    needs: resolve
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-ci-linux.yml
+    with:
+      amdgpu_families: dcgpu-all;dgpu-all;igpu-all
+      artifact_group: nightly-rocgdb-multiarch
+      build_runs_on: ${{ needs.resolve.outputs.build_runs_on }}
+      therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      build_image: ${{ needs.resolve.outputs.build_image }}
+      rocgdb_ref: ${{ inputs.branch || 'master' }}
+      extra_cmake_options: >
+        -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
+        -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
+        -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
+        -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
+        -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
+        -DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON
+        -DTHEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON
+
+  test-gpu:
+    name: Test GPU
+    needs: [nightly-rocgdb-build-linux]
+    if: ${{ needs.nightly-rocgdb-build-linux.result == 'success' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: nightly-rocgdb-multiarch
+      therock_ref: ${{ needs.nightly-rocgdb-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+
+  test-cpu:
+    name: Test CPU
+    needs: [nightly-rocgdb-build-linux]
+    if: ${{ needs.nightly-rocgdb-build-linux.result == 'success' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      # CPU tests are gfx-independent; gfx94X selects the artifact set to fetch.
+      amdgpu_families: gfx94X
+      artifact_group: nightly-rocgdb-multiarch
+      therock_ref: ${{ needs.nightly-rocgdb-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-cpu
+
+  nightly_build_summary:
+    name: Nightly Build Summary
+    if: always()
+    needs:
+      - resolve
+      - nightly-rocgdb-build-linux
+      - test-gpu
+      - test-cpu
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,10 @@ on:
         type: string
       extra_cmake_options:
         type: string
+      rocgdb_ref:
+        type: string
+        required: false
+        description: 'ROCgdb branch/ref to checkout (defaults to workflow trigger ref)'
       build_runs_on:
         type: string
         default: aws-linux-scale-rocm-prod
@@ -61,6 +65,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: rocgdb_under_test
+          ref: ${{ inputs.rocgdb_ref || github.sha }}
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Fetch sources
         run: |
+          # debug-tools only requires core build infrastructure; the excluded groups
+          # (rocm-libraries, ml-frameworks, media-libs, math-libraries) are not needed.
           ./build_tools/fetch_sources.py --jobs 12 --depth 1 \
             --no-include-rocm-libraries \
             --no-include-ml-frameworks \

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -12,38 +12,31 @@ on:
       build_runs_on:
         type: string
         default: aws-linux-scale-rocm-prod
+      therock_commit_ref:
+        type: string
+        required: true
+      build_image:
+        type: string
+        required: true
+    outputs:
+      therock_ref:
+        value: ${{ jobs.therock-build-linux.outputs.therock_ref }}
 
 permissions:
   contents: read
 
 jobs:
-  resolve:
-    name: Resolve TheRock references
-    runs-on: ubuntu-24.04
-    outputs:
-      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
-      build_image: ${{ steps.read.outputs.build_image }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Read TheRock dependency pins
-        id: read
-        run: python3 .github/scripts/config.py therock_commit_ref build_image
-
   therock-build-linux:
     name: Build Linux Packages
-    needs: resolve
     runs-on: ${{ inputs.build_runs_on }}
     permissions:
       contents: read
       id-token: write
     outputs:
-      therock_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      therock_ref: ${{ inputs.therock_commit_ref }}
     container:
-      image: ${{ needs.resolve.outputs.build_image }}
+      image: ${{ inputs.build_image }}
     env:
-      THEROCK_COMMIT_REF: ${{ needs.resolve.outputs.therock_commit_ref }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       CACHE_DIR: ${{ github.workspace }}/.container-cache
@@ -54,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+          ref: ${{ inputs.therock_commit_ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -91,7 +84,11 @@ jobs:
 
       - name: Fetch sources
         run: |
-          ./build_tools/fetch_sources.py --jobs 12
+          ./build_tools/fetch_sources.py --jobs 12 --depth 1 \
+            --no-include-rocm-libraries \
+            --no-include-ml-frameworks \
+            --no-include-media-libs \
+            --no-include-math-libraries
 
       - name: Configure Projects
         env:
@@ -141,17 +138,6 @@ jobs:
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
-            --artifact-group ${{ env.AMDGPU_FAMILIES }} \
+            --artifact-group ${{ inputs.artifact_group }} \
             --build-dir build \
             --upload
-
-  therock-test-linux:
-    name: "Run Tests"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
-    needs: [therock-build-linux]
-    uses: ./.github/workflows/therock-test-packages.yml
-    with:
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      artifact_group: ${{ inputs.artifact_group }}
-      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
-      artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -33,49 +33,106 @@ jobs:
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
-      - name: Checkout CI config
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: ROCm/therock-ci-config
-          ref: main
-          path: ci-config
-        continue-on-error: true
-
       - name: Select build runner
         id: runner
         run: python3 .github/scripts/select_runner.py build_runs_on
 
-  therock-ci-linux:
-    name: TheRock CI Linux
+  resolve:
+    name: Resolve TheRock references
     needs: setup
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
+      build_image: ${{ steps.read.outputs.build_image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read TheRock dependency pins
+        id: read
+        run: python3 .github/scripts/config.py therock_commit_ref build_image
+
+  therock-build-linux:
+    name: Build Linux Packages
+    needs: [setup, resolve]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        amdgpu_family: [gfx94X-dcgpu]
     uses: ./.github/workflows/therock-ci-linux.yml
     with:
-      amdgpu_families: ${{ matrix.amdgpu_family }}
-      artifact_group: ${{ matrix.amdgpu_family }}
+      amdgpu_families: dcgpu-all;dgpu-all;igpu-all
+      artifact_group: gfx94X
       build_runs_on: ${{ needs.setup.outputs.build_runs_on }}
+      therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      build_image: ${{ needs.resolve.outputs.build_image }}
       extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
+        -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
         -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
         -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
         -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
         -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
         -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
 
+  test-gpu:
+    name: Test GPU
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family:
+          - gfx94X
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+
+  test-cpu:
+    name: Test CPU
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-cpu
+
+  test-corefile:
+    name: Test corefile (gfx942)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx942
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-corefile
+
   therock_ci_summary:
     name: TheRock CI Summary
     if: always()
     needs:
       - setup
-      - therock-ci-linux
+      - therock-build-linux
+      - test-gpu
+      - test-cpu
+      - test-corefile
     runs-on: ubuntu-24.04
     steps:
       - name: Output failed jobs

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -2,6 +2,7 @@ name: TheRock CI for rocgdb
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - amd-staging
       - amd-staging-rocgdb-*
@@ -23,6 +24,8 @@ jobs:
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
       build_runs_on: ${{ steps.runner.outputs.build_runs_on }}
+      test_families: ${{ steps.families.outputs.test_families }}
+      artifact_group: ${{ steps.families.outputs.artifact_group }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,6 +39,16 @@ jobs:
       - name: Select build runner
         id: runner
         run: python3 .github/scripts/select_runner.py build_runs_on
+
+      - name: Select GPU test families
+        id: families
+        run: |
+          echo 'artifact_group=gfx94X' >> $GITHUB_OUTPUT
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:run-all-archs') }}" == "true" ]]; then
+            echo 'test_families=["gfx94X","gfx90a","gfx950","gfx110X","gfx1151","gfx120X"]' >> $GITHUB_OUTPUT
+          else
+            echo 'test_families=["gfx94X"]' >> $GITHUB_OUTPUT
+          fi
 
   resolve:
     name: Resolve TheRock references
@@ -63,10 +76,11 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     with:
       amdgpu_families: dcgpu-all;dgpu-all;igpu-all
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       build_runs_on: ${{ needs.setup.outputs.build_runs_on }}
       therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
       build_image: ${{ needs.resolve.outputs.build_image }}
+      # Multi-arch builds cannot use the default bundle name (derived from amdgpu_families).
       extra_cmake_options: >
         -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
         -DTHEROCK_ENABLE_ALL=OFF
@@ -86,12 +100,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amdgpu_family:
-          - gfx94X
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-gpu
@@ -105,7 +118,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       amdgpu_families: gfx94X
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-cpu
@@ -118,8 +131,9 @@ jobs:
       contents: read
     uses: ./.github/workflows/therock-test-packages.yml
     with:
+      # gfx942 is intentional: we only have a gfx942 corefile runner for rocgdb corefile testing.
       amdgpu_families: gfx942
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-corefile

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -138,6 +138,100 @@ jobs:
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-corefile
 
+  # Extended test configurations. These reuse the single build from
+  # therock-build-linux (no rebuild) and fan out in parallel with each other
+  # and with the standard tests, all gated on a successful build.
+  #
+  # The two optimization jobs (test-gpu-o3, test-gpu-lto) follow the same
+  # test_families matrix as test-gpu, so with ci:run-all-archs each adds up
+  # to six GPU jobs (one per architecture family). The check-type and hip
+  # board jobs run on gfx94X only.
+  test-gpu-o3:
+    name: Test GPU (-O3)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu,rocgdb-corefile
+      test_options: "--optimization=-O3"
+
+  test-gpu-lto:
+    name: Test GPU (-O3 -flto)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu,rocgdb-corefile
+      test_options: "--optimization='-O3 -flto'"
+
+  test-gpu-check-read1:
+    name: Test GPU (check-read1)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-read1"
+
+  test-gpu-check-readmore:
+    name: Test GPU (check-readmore)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-readmore"
+
+  test-gpu-hip-board:
+    name: Test GPU (hip board)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+      test_options: >-
+        --runtestflags=--target_board=hip
+        --tests gdb.base/attach.exp gdb.base/start.exp gdb.base/callfuncs.exp
+        gdb.base/consecutive-step-over.exp gdb.base/ending-run.exp
+        gdb.base/finish.exp gdb.base/hbreak.exp gdb.base/signals.exp
+        gdb.base/step-test.exp gdb.base/watchpoint.exp
+
   therock_ci_summary:
     name: TheRock CI Summary
     if: always()
@@ -147,6 +241,11 @@ jobs:
       - test-gpu
       - test-cpu
       - test-corefile
+      - test-gpu-o3
+      - test-gpu-lto
+      - test-gpu-check-read1
+      - test-gpu-check-readmore
+      - test-gpu-hip-board
     runs-on: ubuntu-24.04
     steps:
       - name: Output failed jobs

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -185,7 +185,7 @@ jobs:
       test_options: "--optimization='-O3 -flto'"
 
   test-gpu-check-read1:
-    name: Test GPU (check-read1)
+    name: Test check-read1
     needs: [setup, therock-build-linux]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
@@ -199,7 +199,7 @@ jobs:
       test_options: "--check-type check-read1"
 
   test-gpu-check-readmore:
-    name: Test GPU (check-readmore)
+    name: Test check-readmore
     needs: [setup, therock-build-linux]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:

--- a/.github/workflows/therock-deps-update.yml
+++ b/.github/workflows/therock-deps-update.yml
@@ -1,9 +1,8 @@
 name: Update TheRock Dependencies
 
 on:
-  # schedule: # runs twice daily (03:17 and 15:17 UTC)
-  #   - cron: '17 3 * * *'
-  #   - cron: '17 15 * * *'
+  schedule: # runs weekly on Mondays at 03:17 UTC
+    - cron: '17 3 * * 1'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -38,4 +37,4 @@ jobs:
 
       - name: Update TheRock references
         run: |
-          python3 .github/scripts/update_therock_deps.py ${{ inputs.dry_run && '--dry-run' || '' }}
+          python3 .github/scripts/update_therock_deps.py ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '--dry-run' || '' }}

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -11,6 +11,9 @@ on:
         required: true
       amdgpu_families:
         type: string
+      artifact_group:
+        type: string
+        default: ""
       test_runs_on:
         type: string
       component:
@@ -39,7 +42,6 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: "./build"
       VENV_DIR: ${{ github.workspace }}/.venv
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-      ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
 
     steps:
       - name: Fetch 'build_tools' from TheRock
@@ -65,7 +67,7 @@ jobs:
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group != '' && inputs.artifact_group || inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -7,22 +7,30 @@ on:
         type: string
       artifact_group:
         type: string
+        default: ""
       therock_ref:
         type: string
         required: true
       artifact_run_id:
         type: string
+      projects_to_test:
+        type: string
+        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
   workflow_dispatch:
     inputs:
       amdgpu_families:
         type: string
       artifact_group:
         type: string
+        default: ""
       therock_ref:
         type: string
         required: true
       artifact_run_id:
         type: string
+      projects_to_test:
+        type: string
+        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
 
 permissions:
   contents: read
@@ -71,7 +79,7 @@ jobs:
 
       - name: Configure test matrix
         env:
-          PROJECTS_TO_TEST: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+          PROJECTS_TO_TEST: ${{ inputs.projects_to_test }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           CI_CONFIG_PATH: ci-config
         id: configure
@@ -108,6 +116,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       therock_ref: ${{ inputs.therock_ref }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
       # Per-component runner selection:
       #   1. CPU-only components use the runner from therock-ci-config
       #   2. GPU components use the per-component runner from fetch_test_configurations.py

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -13,9 +13,14 @@ on:
         required: true
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Job-specific options appended to each component test_script.'
+        default: ''
       projects_to_test:
         type: string
-        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+        description: 'Components to build the test matrix for.'
+        default: 'rocgdb-cpu,rocgdb-gpu,rocgdb-corefile'
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -28,9 +33,14 @@ on:
         required: true
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Job-specific options appended to each component test_script.'
+        default: ''
       projects_to_test:
         type: string
-        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+        description: 'Components to build the test matrix for.'
+        default: 'rocgdb-cpu,rocgdb-gpu,rocgdb-corefile'
 
 permissions:
   contents: read
@@ -84,13 +94,32 @@ jobs:
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-      - name: Set rocgdb test_script
-        # TheRock now emits the installed script path directly; no rewrite needed.
+      - name: Patch rocgdb test_script options
+        # Append caller-supplied options to each component's test_script.
+        # When test_options contains --tests, first strip any pre-existing
+        # --tests from the upstream test_script so the caller's value wins
+        # explicitly rather than relying on argparse last-wins behaviour.
         id: patch-scripts
         env:
           COMPONENTS: ${{ steps.configure.outputs.components }}
+          TEST_OPTIONS: ${{ inputs.test_options }}
         run: |
-          echo "components=$COMPONENTS" >> $GITHUB_OUTPUT
+          strip_tests=false
+          if [[ " $TEST_OPTIONS " == *" --tests "* ]]; then
+            strip_tests=true
+          fi
+          updated=$(echo "$COMPONENTS" | jq -c \
+            --arg opts "$TEST_OPTIONS" \
+            --argjson strip "$strip_tests" '
+            map(
+              .test_script |= (
+                if $strip then gsub("--tests(\\s+[^-]\\S*)*"; "") else . end
+                | if $opts != "" then . + " " + $opts else . end
+                | gsub("  +"; " ") | sub("\\s+$"; "")
+              )
+            )
+          ')
+          echo "components=$updated" >> $GITHUB_OUTPUT
 
   test_components:
     name: "Test ${{ matrix.components.job_name }}"

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -37,7 +37,6 @@ permissions:
 
 env:
   VENV_DIR: ${{ github.workspace }}/.venv
-  OUTPUT_ARTIFACTS_DIR: "./build"
 
 jobs:
   configure_test_matrix:
@@ -85,23 +84,13 @@ jobs:
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-      - name: Override rocgdb test_script to use artifact-installed script
-        # TheRock's fetch_test_configurations.py points test_rocgdb.py at its own
-        # build_tools copy. Rewrite to the script installed in the artifacts at
-        # OUTPUT_ARTIFACTS_DIR/tests/rocgdb/test_rocgdb.py.
+      - name: Set rocgdb test_script
+        # TheRock now emits the installed script path directly; no rewrite needed.
         id: patch-scripts
+        env:
+          COMPONENTS: ${{ steps.configure.outputs.components }}
         run: |
-          components='${{ steps.configure.outputs.components }}'
-          script_path="${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py"
-          updated=$(echo "$components" | jq -c --arg s "$script_path" '
-            map(
-              .test_script |= gsub(
-                "build_tools/github_actions/test_executable_scripts/test_rocgdb\\.py";
-                $s
-              )
-            )
-          ')
-          echo "components=$updated" >> $GITHUB_OUTPUT
+          echo "components=$COMPONENTS" >> $GITHUB_OUTPUT
 
   test_components:
     name: "Test ${{ matrix.components.job_name }}"

--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -7,6 +7,11 @@ Full documentation for ROCgdb is available at
 
 ### Added
 
+- Improve "maint print address-spaces" command to display properties
+  of address spaces supported by an architecture.  For each address
+  space, print its name, DWARF id, address size, null address, and
+  access class.
+
 - The "catch hiperr" feature is now exposed to MI too, with a new
   `-catch-hiperr` command and related fields in `*stopped` records.
   See the "HIP Runtime Error" subsection of the "GDB/MI Catchpoint

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -1839,6 +1839,32 @@ amd64_linux_fetch_hiperr_info (frame_info_ptr frame)
   return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGILL occurs.  */
+
+static bool
+amd64_linux_should_show_inline_frame (struct gdbarch *gdbarch,
+				      const struct symbol *func,
+				      enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to illegal instruction.
+     The ud2 instruction used by verbose traps on x86_64 generates SIGILL.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ILL)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static void
 amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
 			    int num_disp_step_buffers)
@@ -1897,6 +1923,11 @@ amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
   /* Extract hiperr info for 'catch hiperr'.  */
   set_gdbarch_fetch_hiperr_info
     (gdbarch, amd64_linux_fetch_hiperr_info);
+
+  /* Show verbose trap inline frames when stopped due to illegal
+     instruction.  */
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amd64_linux_should_show_inline_frame);
 }
 
 static void

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -2022,6 +2022,31 @@ amdgpu_supports_arch_info (const struct bfd_arch_info *info)
   return status == AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+/* Determine whether to show an inline frame.
+   Show verbose trap frames (__clang_trap_msg$...) when SIGABRT occurs.  */
+
+static bool
+amdgpu_should_show_inline_frame (struct gdbarch *gdbarch,
+				 const struct symbol *func,
+				 enum gdb_signal stop_signal)
+{
+  /* Only show verbose trap frames when stopped due to abort signal.
+     This ensures we only show the frame when the trap actually fired,
+     not when user stepped into it with commands like "step".  */
+  if (stop_signal != GDB_SIGNAL_ABRT)
+    return false;
+
+  /* Check if this is a verbose trap inline frame by looking for the
+     compiler-generated function name pattern.  */
+  const char *name = func->linkage_name ();
+  if (name == nullptr)
+    return false;
+
+  /* Verbose trap frames have names like:
+     "__clang_trap_msg$<category>$<message>"  */
+  return startswith (name, "__clang_trap_msg$");
+}
+
 static struct gdbarch *
 amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 {
@@ -2273,6 +2298,9 @@ amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
     error (_("amd_dbgapi_architecture_get_info failed"));
 
   set_gdbarch_decr_pc_after_break (gdbarch, pc_adjust);
+
+  set_gdbarch_should_show_inline_frame
+    (gdbarch, amdgpu_should_show_inline_frame);
 
   /* Get info about address spaces.  */
   size_t address_space_count;

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1619,6 +1619,18 @@ core_file_exec_context::environment () const
   return e;
 }
 
+/* See arch-utils.h.  */
+
+/* Default implementation: don't show inline frames.  */
+
+bool
+default_should_show_inline_frame (struct gdbarch *gdbarch,
+				  const struct symbol *func,
+				  enum gdb_signal stop_signal)
+{
+  return false;
+}
+
 void _initialize_gdbarch_utils ();
 void
 _initialize_gdbarch_utils ()

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -455,4 +455,9 @@ extern int default_supported_lanes_count (struct gdbarch *gdbarch,
 extern std::vector<addr_range> default_get_watchable_aliases
   (struct gdbarch *gdbarch, ptid_t ptid, int simd_lane, addr_range range);
 
+/* Default implementation of gdbarch_should_show_inline_frame.  */
+extern bool default_should_show_inline_frame
+  (struct gdbarch *gdbarch, const struct symbol *func,
+   enum gdb_signal stop_signal);
+
 #endif /* GDB_ARCH_UTILS_H */

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -273,6 +273,7 @@ struct gdbarch
   gdbarch_read_core_file_mappings_ftype *read_core_file_mappings = default_read_core_file_mappings;
   gdbarch_use_target_description_from_corefile_notes_ftype *use_target_description_from_corefile_notes = default_use_target_description_from_corefile_notes;
   gdbarch_core_parse_exec_context_ftype *core_parse_exec_context = default_core_parse_exec_context;
+  gdbarch_should_show_inline_frame_ftype *should_show_inline_frame = default_should_show_inline_frame;
 };
 
 /* Create a new ``struct gdbarch'' based on information provided by
@@ -567,6 +568,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of read_core_file_mappings, invalid_p == 0.  */
   /* Skip verify of use_target_description_from_corefile_notes, invalid_p == 0.  */
   /* Skip verify of core_parse_exec_context, invalid_p == 0.  */
+  /* Skip verify of should_show_inline_frame, invalid_p == 0.  */
   if (!log.empty ())
     internal_error (_("verify_gdbarch: the following are invalid ...%s"),
 		    log.c_str ());
@@ -1483,6 +1485,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: core_parse_exec_context = <%s>\n",
 	      host_address_to_string (gdbarch->core_parse_exec_context));
+  gdb_printf (file,
+	      "gdbarch_dump: should_show_inline_frame = <%s>\n",
+	      host_address_to_string (gdbarch->should_show_inline_frame));
   if (gdbarch->dump_tdep != NULL)
     gdbarch->dump_tdep (gdbarch, file);
 }
@@ -5842,4 +5847,21 @@ set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch,
 				     gdbarch_core_parse_exec_context_ftype core_parse_exec_context)
 {
   gdbarch->core_parse_exec_context = core_parse_exec_context;
+}
+
+bool
+gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal)
+{
+  gdb_assert (gdbarch != NULL);
+  gdb_assert (gdbarch->should_show_inline_frame != NULL);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_should_show_inline_frame called\n");
+  return gdbarch->should_show_inline_frame (gdbarch, func, stop_signal);
+}
+
+void
+set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch,
+				      gdbarch_should_show_inline_frame_ftype should_show_inline_frame)
+{
+  gdbarch->should_show_inline_frame = should_show_inline_frame;
 }

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1893,3 +1893,25 @@ extern void set_gdbarch_use_target_description_from_corefile_notes (struct gdbar
 typedef core_file_exec_context (gdbarch_core_parse_exec_context_ftype) (struct gdbarch *gdbarch, bfd *cbfd);
 extern core_file_exec_context gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, bfd *cbfd);
 extern void set_gdbarch_core_parse_exec_context (struct gdbarch *gdbarch, gdbarch_core_parse_exec_context_ftype *core_parse_exec_context);
+
+/* Determine whether an inline frame should be shown in backtraces.
+
+   This hook is called when GDB encounters an inline frame to decide whether
+   it should be displayed to the user or hidden.  By default, inline frames
+   are hidden during normal stepping to provide a source-level debugging
+   experience.  However, some inline frames contain important diagnostic
+   information that should always be visible.
+
+   A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+   which embed crash diagnostic messages in specially-named inline frames.
+   When such a trap fires, the inline frame should be shown even though
+   inline frames are normally hidden.
+
+   The hook receives the inline frame's symbol and the signal that stopped
+   execution, allowing architecture-specific code to make the decision.
+
+   Return true if the inline frame should be shown, false to hide it. */
+
+typedef bool (gdbarch_should_show_inline_frame_ftype) (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+extern bool gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, const struct symbol *func, enum gdb_signal stop_signal);
+extern void set_gdbarch_should_show_inline_frame (struct gdbarch *gdbarch, gdbarch_should_show_inline_frame_ftype *should_show_inline_frame);

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2998,3 +2998,30 @@ which all assume current_inferior() is the one to read from.
     predefault="default_core_parse_exec_context",
     invalid=False,
 )
+
+Method(
+    comment="""
+Determine whether an inline frame should be shown in backtraces.
+
+This hook is called when GDB encounters an inline frame to decide whether
+it should be displayed to the user or hidden.  By default, inline frames
+are hidden during normal stepping to provide a source-level debugging
+experience.  However, some inline frames contain important diagnostic
+information that should always be visible.
+
+A common use case is verbose trap frames (e.g., __builtin_verbose_trap)
+which embed crash diagnostic messages in specially-named inline frames.
+When such a trap fires, the inline frame should be shown even though
+inline frames are normally hidden.
+
+The hook receives the inline frame's symbol and the signal that stopped
+execution, allowing architecture-specific code to make the decision.
+
+Return true if the inline frame should be shown, false to hide it.
+""",
+    type="bool",
+    name="should_show_inline_frame",
+    params=[("const struct symbol *", "func"), ("enum gdb_signal", "stop_signal")],
+    predefault="default_should_show_inline_frame",
+    invalid=False,
+)

--- a/gdb/inline-frame.c
+++ b/gdb/inline-frame.c
@@ -28,6 +28,7 @@
 #include "regcache.h"
 #include "symtab.h"
 #include "frame.h"
+#include "gdbarch.h"
 #include "cli/cli-cmds.h"
 #include "cli/cli-style.h"
 #include <algorithm>
@@ -432,10 +433,14 @@ skip_inline_frames (thread_info *thread, bpstat *stop_chain)
      which contains all of the inlined functions, we never skip this.  */
   int skipped_frames = 0;
 
+  struct gdbarch *gdbarch = get_frame_arch (get_current_frame ());
+  enum gdb_signal stop_signal = thread->stop_signal ();
+
   for (const auto sym : function_symbols)
     {
       if (stopped_by_user_bp_inline_frame (sym, stop_chain)
-	  || sym == function_symbols.back ())
+	  || sym == function_symbols.back ()
+	  || gdbarch_should_show_inline_frame (gdbarch, sym, stop_signal))
 	break;
 
       ++skipped_frames;

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.cpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+void
+test_trap_function ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_function ();
+  return 0;
+}

--- a/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.base/builtin_verbose_trap.exp
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap inline frames are shown when trap fires.
+# __builtin_verbose_trap is a Clang-only builtin, added in Clang 19.
+
+require {expr {[test_compiler_info clang*]
+	       && ![test_compiler_info {clang-1[0-8]-*}]
+	       && ![test_compiler_info {clang-[1-9]-*}]}}
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction with the
+# previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug c++}]} {
+    return
+}
+
+if {![runto test_trap_function]} {
+    return
+}
+
+# Continue to trigger the trap.
+gdb_test "continue" \
+    "received signal SIGILL.*" \
+    "received trap signal"
+
+# Verify verbose trap message appears in backtrace.
+gdb_test "bt" \
+    "This is verbose trap.*" \
+    "verbose trap message appears in backtrace"
+
+# Test single stepping to the trap line.
+# Expected: step should stop at __builtin_verbose_trap line, then
+# next step triggers the trap.
+clean_restart $testfile
+
+if {![runto_main]} {
+    return
+}
+
+# Set breakpoint at "int x = 1" line to avoid line table ambiguity
+# when running to the test function.
+set line_x [gdb_get_line_number "int x = 1"]
+gdb_breakpoint "$srcfile:$line_x"
+gdb_test "continue" "Breakpoint.*$line_x.*" "run to line $line_x"
+
+# Check for compiler line table bug using info line.
+# If the __builtin_verbose_trap line shows "contains no code",
+# the trap instruction is not mapped to that line (bug exists).
+set has_line_table_bug 0
+set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+gdb_test_multiple "info line $line_trap" "" {
+    -re "contains no code" {
+	set has_line_table_bug 1
+	exp_continue
+    }
+    -re -wrap "" {
+	pass $gdb_test_name
+    }
+}
+
+gdb_test_multiple "next" "step to trap line" {
+    -re -wrap "SIGILL.*" {
+	if {$has_line_table_bug} {
+	    xfail "$gdb_test_name (compiler line table bug)"
+	} else {
+	    fail "$gdb_test_name"
+	}
+    }
+    -re -wrap "__builtin_verbose_trap.*" {
+	pass $gdb_test_name
+
+	# Next step should trigger the trap.
+	gdb_test "next" "SIGILL.*" "step triggers trap"
+    }
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.cpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <hip/hip_runtime.h>
+
+__global__ void
+test_trap_kernel ()
+{
+  int x = 1;
+  __builtin_verbose_trap ("check verbose", "This is verbose trap!");
+}
+
+int
+main ()
+{
+  test_trap_kernel<<<1, 1>>> ();
+  return hipDeviceSynchronize () != hipSuccess;
+}

--- a/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
+++ b/gdb/testsuite/gdb.rocm/builtin_verbose_trap.exp
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that __builtin_verbose_trap PC is correctly adjusted.
+
+load_lib rocm.exp
+require allow_hip_tests
+
+# Compiler Line Table Bug:
+# Some Clang versions emit incorrect line table information for
+# __builtin_verbose_trap, associating the trap instruction
+# with the previous source line instead of the __builtin_verbose_trap line.
+# This causes GDB to receive the trap signal immediately when stepping past
+# that line, rather than stopping at the __builtin_verbose_trap call first.
+# The tests below use xfail to handle this known compiler issue.
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+with_rocm_gpu_lock {
+    if {![runto test_trap_kernel allow-pending]} {
+	return
+    }
+
+    # Continue to trigger the trap.
+    gdb_test "continue" \
+	"received signal SIGABRT.*" \
+	"received trap signal"
+
+    # Check PC points to trap instruction.
+    gdb_test "x/i \$pc" \
+	"s_trap.*" \
+	"PC points to trap instruction"
+
+    # Verify verbose trap message appears in backtrace.
+    gdb_test "bt" \
+	"This is verbose trap.*" \
+	"verbose trap message appears in backtrace"
+
+    # Test single stepping to the trap line.
+    # Expected: step should stop at __builtin_verbose_trap line, then
+    # next step triggers the trap.
+    clean_restart $testfile
+
+    if {![runto test_trap_kernel allow-pending]} {
+	return
+    }
+
+    # Check for compiler line table bug using info line.
+    # If the __builtin_verbose_trap line shows "contains no code",
+    # the trap instruction is not mapped to that line (bug exists).
+    set has_line_table_bug 0
+    set line_trap [gdb_get_line_number "__builtin_verbose_trap"]
+
+    gdb_test_multiple "info line $line_trap" "" {
+	-re "contains no code" {
+	    set has_line_table_bug 1
+	    exp_continue
+	}
+	-re -wrap "" {
+	    pass $gdb_test_name
+	}
+    }
+
+    gdb_test_multiple "next" "step to trap line" {
+	-re -wrap "SIGABRT.*" {
+	    if {$has_line_table_bug} {
+		xfail "$gdb_test_name (compiler line table bug)"
+	    } else {
+		fail "$gdb_test_name"
+	    }
+	}
+	-re -wrap "__builtin_verbose_trap.*" {
+	    pass $gdb_test_name
+
+	    # Next step should trigger the trap.
+	    gdb_test "next" "SIGABRT.*" "step triggers trap"
+	}
+    }
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
@@ -27,13 +27,17 @@
 #define N 32
 
 #pragma omp declare target
-static int
+/* optnone prevents the compiler from optimizing x away, keeping it
+   readable in the debugger.  */
+static int __attribute__((optnone))
 square_dev (int x)
 {
   return x * x;
 }
 
-static int
+/* optnone prevents the compiler from optimizing x away, keeping it
+   readable in the debugger.  */
+static int __attribute__((optnone))
 cube_dev (int x)
 {
   return x * x * x;

--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
@@ -23,21 +23,25 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 
 /* Helper function where the debugger places a breakpoint to be sure no wave
-   can run to completion without the debugger noticing.  optnone implies
-   noinline and keeps the body opaque to the optimizer, so the breakpoint is
-   reliable and the call is not proven away under -O1/-O2/-O3.  */
-__device__ void __attribute__ ((optnone))
+   can run to completion without the debugger noticing.  __forceinline__ and
+   volatile asm guarantee the s_nop is emitted in-line in the kernel, giving
+   the debugger a reliable address to break on.  */
+__device__ __forceinline__ void
 end_of_kernel ()
 {
+  __asm__ volatile ("s_nop 0" ::: );  /* Debugger breaks on the inlined s_nop.  */
 }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 kern ()
 {
-  /* The test will need to step a few times, so provide an empty loop that
-     will make it possible.  */
-  for (int i = 0; i < 100; i++)
-    __builtin_amdgcn_s_sleep (1);
+  /* The test will need to step a few times.  */
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
 
   end_of_kernel ();
 }

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -20,6 +20,11 @@ load_lib rocm.exp
 
 require allow_hip_tests
 
+# This test writes to a __device__ global's storage from a CPU thread,
+# which only works where that memory is host-accessible (an APU, or
+# XNACK/HMM unified memory).  Skip it on GPUs that cannot do this.
+require hip_devices_support_host_access_to_global
+
 standard_testfile .cpp
 
 if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -501,6 +501,42 @@ proc hip_devices_support_debug_multi_process {} {
     return 1
 }
 
+# Return true if a CPU thread can write to a __device__ global's
+# storage (the address obtained via hipGetSymbolAddress).
+
+gdb_caching_proc hip_devices_support_host_access_to_global {} {
+    if {![gdb_simple_compile host_access_to_global {
+	    #include <hip/hip_runtime.h>
+
+	    __device__ int global = 0;
+
+	    __global__ void kern () {}
+
+	    int __attribute__ ((optnone))
+	    main ()
+	    {
+	      kern<<<1, 1>>> ();
+	      if (hipDeviceSynchronize () != hipSuccess)
+		return 1;
+
+	      int *dev_global;
+	      if (hipGetSymbolAddress (reinterpret_cast<void **> (&dev_global),
+				       global))
+		return 2;
+
+	      /* This store faults on GPUs whose device memory is not
+		 host-accessible.  */
+	      *static_cast<volatile int *> (dev_global) = 8;
+	      return 0;
+	    }
+	} executable hip]} {
+	return 0
+    }
+
+    set result [log_host_exec "$obj"]
+    return [expr {[lindex $result 0] == 0}]
+}
+
 # Helpers below gate cooperative-group debugging tests, i.e. tests that
 # debug kernels launched with hipLaunchCooperativeKernel and
 # synchronized via cooperative_groups::this_grid ().sync ().


### PR DESCRIPTION
Commits:
bded4db6708 gdb: Show __builtin_verbose_trap message in backtraces
1b41694ab26 Update TheRock dependencies and container images
9d8e35f7a67 Add nightly build workflow for ROCgdb master branch
8373b3bb598 [testsuite] gdb.rocm/omp-target-multi-kernel: fix optimized-out x
a1f5cb25ad6 Update CHANGELOG_AMD.md with new maint print address-spaces feature.
c8b73c0b6ff [workflows] Rename check-type jobs: drop misleading 'GPU' prefix
8a50b788c59 [workflows] Run extended ROCgdb tests in parallel on PRs
2e1134f6da7 [workflows] Drop now-redundant test_rocgdb.py path rewrite
af1f609b146 .github: automerge: unshallow repo before merge-base
52526a743bf .github: add automerge workflow
92dd5960a52 .github: add automerge script for upstream sync
dbbcf23990f .github/scripts: apply black formatting
01f2c8d67d9 gdb.rocm: skip watch-gpu-global-from-host where device memory is not host-accessible
e5133af911d gdb.rocm: step-schedlock-spurious-waves.cpp: Use inlined asm for breakpoint
8af5d945061 ci: add ci:run-all-archs label to expand GPU test coverage
138c974781b ci: restructure TheRock CI to reduce redundancy
d639b376781 github: schedule therock deps update to run weekly on Mondays
b403d37fafa Add automerge workflow