### PR TITLE
Add "info waves", "info waves count", -wave-info, -wave-count

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -4058,6 +4058,7 @@ info_agents_command (const char *args, int from_tty)
 }
 
 static struct cmd_list_element *queue_list;
+static struct cmd_list_element *wave_list;
 
 static void
 info_queues_command (const char *args, int from_tty)
@@ -4368,6 +4369,124 @@ num_digits (T value)
 }
 
 static struct cmd_list_element *dispatch_list;
+
+/* Wave counts broken down by state.  */
+
+struct wave_counts
+{
+  size_t total = 0;
+  size_t running = 0;
+  size_t single_stepping = 0;
+  size_t stopped = 0;
+};
+
+/* Return wave counts for INF, querying the dbgapi directly.  */
+
+static wave_counts
+count_waves (inferior *inf)
+{
+  amd_dbgapi_process_id_t process_id = get_amd_dbgapi_process_id (inf);
+  wave_counts counts;
+
+  if (process_id == AMD_DBGAPI_PROCESS_NONE)
+    return counts;
+
+  amd_dbgapi_wave_id_t *waves;
+  size_t wave_count;
+  if (amd_dbgapi_process_wave_list (process_id, &wave_count, &waves,
+				    nullptr)
+      != AMD_DBGAPI_STATUS_SUCCESS)
+    return counts;
+
+  for (size_t i = 0; i < wave_count; ++i)
+    {
+      amd_dbgapi_wave_state_t state;
+      if (amd_dbgapi_wave_get_info (waves[i], AMD_DBGAPI_WAVE_INFO_STATE,
+				    sizeof (state), &state)
+	  != AMD_DBGAPI_STATUS_SUCCESS)
+	/* Skip waves whose state cannot be retrieved; they are not
+	   reflected in counts.total.  */
+	continue;
+
+      ++counts.total;
+      switch (state)
+	{
+	case AMD_DBGAPI_WAVE_STATE_RUN:
+	  ++counts.running;
+	  break;
+	case AMD_DBGAPI_WAVE_STATE_SINGLE_STEP:
+	  ++counts.single_stepping;
+	  break;
+	case AMD_DBGAPI_WAVE_STATE_STOP:
+	  ++counts.stopped;
+	  break;
+	default:
+	  /* Unknown state from a newer dbgapi version.  The wave is
+	     counted in total but not in any sub-bucket.  */
+	  break;
+	}
+    }
+
+  xfree (waves);
+  return counts;
+}
+
+/* Parse an optional inferior number from ARGS.  Returns the current inferior
+   if ARGS is empty, or the inferior with the given number if ARGS is non-empty.
+   Throws an error if the number is out of range or refers to a non-existent
+   inferior.  */
+
+static inferior *
+parse_inferior_for_waves (const char *args)
+{
+  if (args == nullptr || *args == '\0')
+    return current_inferior ();
+
+  long num = parse_and_eval_long (args);
+  inferior *inf = (num >= 1 && num <= INT_MAX)
+    ? find_inferior_id ((int) num) : nullptr;
+  if (inf == nullptr)
+    error (_("No inferior number %ld."), num);
+
+  return inf;
+}
+
+static void
+info_waves_command (const char *args, int from_tty)
+{
+  struct ui_out *uiout = current_uiout;
+  inferior *inf = parse_inferior_for_waves (args);
+  wave_counts counts = count_waves (inf);
+
+  if (uiout->is_mi_like_p ())
+    {
+      uiout->field_signed ("total", counts.total);
+      uiout->field_signed ("running", counts.running);
+      uiout->field_signed ("single-stepping", counts.single_stepping);
+      uiout->field_signed ("stopped", counts.stopped);
+    }
+  else
+    {
+      uiout->message (_("%zu waves (%zu running, %zu single-stepping,"
+			" %zu stopped)\n"),
+		      counts.total, counts.running, counts.single_stepping,
+		      counts.stopped);
+    }
+}
+
+static void
+info_waves_count_command (const char *args, int from_tty)
+{
+  struct ui_out *uiout = current_uiout;
+  inferior *inf = parse_inferior_for_waves (args);
+  /* count_waves enumerates all wave states; only total is used here.  */
+  wave_counts counts = count_waves (inf);
+
+  if (uiout->is_mi_like_p ())
+    uiout->field_signed ("count", counts.total);
+  else
+    uiout->message (_("%zu\n"), counts.total);
+}
 
 struct info_dispatches_opts
 {
@@ -5242,6 +5361,24 @@ Otherwise, all dispatches are displayed."),
   auto *c = add_info ("dispatches", info_dispatches_command,
 		      info_dispatches_help.c_str ());
   set_cmd_completer_handle_brkchars (c, info_dispatches_command_completer);
+
+  add_prefix_cmd ("waves", class_info, info_waves_command,
+		  _("Commands for querying heterogeneous waves.\n\
+Usage: info waves [INF-NUM]\n\
+\n\
+Display a summary of active waves in inferior INF-NUM, or in the\n\
+current inferior if INF-NUM is omitted.  If the inferior has no\n\
+active GPU process, all counts are zero."),
+		  &wave_list, 1, &infolist);
+
+  add_cmd ("count", class_info, info_waves_count_command,
+	   _("Display the number of active heterogeneous waves.\n\
+Usage: info waves count [INF-NUM]\n\
+\n\
+Display the total number of waves in inferior INF-NUM, or in the\n\
+current inferior if INF-NUM is omitted.  If the inferior has no\n\
+active GPU process, the count is zero."),
+	   &wave_list);
 
   add_cmd ("address-spaces", class_maintenance,
 	   maintenance_print_address_spaces, _("\

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -24167,8 +24167,8 @@ to disassemble multiple architectures in the same inferior
 executing on multiple heterogeneous agents
 
 @item @code{info agents}, @code{info queues}, @code{info packets},
-@code{info dispatches}, commands to inquire about the heterogeneous
-system
+@code{info dispatches}, @code{info waves}, commands to inquire about
+the heterogeneous system
 
 @item @code{queue find}, @code{dispatch find}, commands to find heterogeneous
 entities
@@ -24528,6 +24528,38 @@ If you're debugging multiple inferiors, @value{GDBN} displays
 heterogeneous dispatch IDs using the qualified
 @var{inferior-num}.@var{dispatch-num} format.  Otherwise, only
 @var{dispatch-num} is shown.
+
+@item info waves @r{[}@var{inferior-num}@r{]}
+@kindex info waves
+Lists the active heterogeneous waves in inferior @var{inferior-num}, or
+in the current inferior if @var{inferior-num} is omitted, broken down by
+state: running, single-stepping, and stopped.  If the inferior has no
+active GPU process, all counts are zero.
+
+For example,
+
+@smallexample
+(@value{GDBP}) info waves
+4096 waves (3840 running, 0 single-stepping, 256 stopped)
+(@value{GDBP}) info waves 2
+1024 waves (1024 running, 0 single-stepping, 0 stopped)
+@end smallexample
+
+@item info waves count @r{[}@var{inferior-num}@r{]}
+@kindex info waves count
+Lists the total number of active heterogeneous waves in inferior
+@var{inferior-num}, or in the current inferior if @var{inferior-num} is omitted.
+This is useful in scripts when only the count is needed.
+If the inferior has no active GPU process, the count is zero.
+
+For example,
+
+@smallexample
+(@value{GDBP}) info waves count
+4096
+(@value{GDBP}) info waves count 2
+1024
+@end smallexample
 
 @item queue find @var{regexp}
 @cindex search for a heterogeneous queue
@@ -38825,6 +38857,85 @@ thread is not associated with a heterogeneous dispatch, or if a
   kernel-desc="0x00007ffde7e00740",kernel-args="0x00007fffeff00000",
   completion="0x0000000000000000",kernel-function="0x00007ffde7e01000"@}​​​​​],
 current-dispatch-id="1.1"
+(gdb)
+@end smallexample
+
+@subheading The @code{-wave-info} Command
+@findex -wave-info
+
+@subsubheading Synopsis
+
+@smallexample
+ -wave-info
+@end smallexample
+
+Lists the active heterogeneous waves in the current inferior, broken
+down by state.
+
+@subsubheading @value{GDBN} Command
+
+The corresponding @value{GDBN} command is @samp{info waves}.
+
+@subsubheading Result
+
+The result contains the following fields:
+
+@table @code
+@item total
+The total number of active waves.
+
+@item running
+The number of waves in the running state.
+
+@item single-stepping
+The number of waves in the single-stepping state.
+
+@item stopped
+The number of waves in the stopped state.
+
+@end table
+
+@subsubheading Example
+
+@smallexample
+(gdb)
+-wave-info
+^done,total="4096",running="3840",single-stepping="0",stopped="256"
+(gdb)
+@end smallexample
+
+@subheading The @code{-wave-count} Command
+@findex -wave-count
+
+@subsubheading Synopsis
+
+@smallexample
+ -wave-count
+@end smallexample
+
+Lists the total number of active heterogeneous waves in the current
+inferior.
+
+@subsubheading @value{GDBN} Command
+
+The corresponding @value{GDBN} command is @samp{info waves count}.
+
+@subsubheading Result
+
+The result contains the following field:
+
+@table @code
+@item count
+The total number of active waves.
+
+@end table
+
+@subsubheading Example
+
+@smallexample
+(gdb)
+-wave-count
+^done,count="4096"
 (gdb)
 @end smallexample
 

--- a/gdb/mi/mi-cmds.c
+++ b/gdb/mi/mi-cmds.c
@@ -303,7 +303,9 @@ add_builtin_mi_commands ()
   add_mi_cmd_mi ("list-features", mi_cmd_list_features);
   add_mi_cmd_mi ("list-target-features", mi_cmd_list_target_features);
   add_mi_cmd_mi ("list-thread-groups", mi_cmd_list_thread_groups);
-  add_mi_cmd_cli ("queue-info", "info queues", 1),
+  add_mi_cmd_cli ("queue-info", "info queues", 1);
+  add_mi_cmd_cli ("wave-count", "info waves count", 1);
+  add_mi_cmd_cli ("wave-info", "info waves", 1);
   add_mi_cmd_mi ("remove-inferior", mi_cmd_remove_inferior);
   add_mi_cmd_mi ("stack-info-depth", mi_cmd_stack_info_depth);
   add_mi_cmd_mi ("stack-info-frame", mi_cmd_stack_info_frame);

--- a/gdb/testsuite/gdb.rocm/info-waves-cli.exp
+++ b/gdb/testsuite/gdb.rocm/info-waves-cli.exp
@@ -1,0 +1,258 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test the "info waves" and "info waves count" CLI commands.
+
+load_lib rocm.exp
+
+require allow_hip_tests
+
+standard_testfile info-waves.cpp
+
+if { [prepare_for_testing "failed to prepare ${testfile}" $testfile $srcfile \
+	{ debug hip }] } {
+    return -1
+}
+
+# Check "info waves count" and "info waves" output.  MIN_TOTAL is the
+# minimum acceptable total.  EXPECT_RUNNING is 1 if running >= 1 is
+# required (non-stop with spinner wave present).  INF_NUM, if given,
+# is passed as an argument to query a specific inferior.
+proc cli_check_waves { min_total expect_running { inf_num "" } } {
+    set suffix ""
+    if { $inf_num ne "" } { set suffix " $inf_num" }
+    set wave_count 0
+    gdb_test_multiple "info waves count$suffix" "info waves count" {
+	-re -wrap "($::decimal)" {
+	    set wave_count $expect_out(1,string)
+	    gdb_assert { $wave_count >= $min_total } $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+    gdb_test_multiple "info waves$suffix" "info waves summary" {
+	-re -wrap "($::decimal) waves \\(($::decimal) running,\
+		   ($::decimal) single-stepping, ($::decimal) stopped\\)" {
+	    set total   $expect_out(1,string)
+	    set running $expect_out(2,string)
+	    set sstep   $expect_out(3,string)
+	    set stopped $expect_out(4,string)
+	    gdb_assert { $total == $wave_count } \
+		"info waves total matches info waves count"
+	    if { $expect_running } {
+		gdb_assert { $running >= 1 } "at least one wave is running"
+	    }
+	    if { $min_total >= 1 } {
+		gdb_assert { $stopped >= 1 } "at least one wave is stopped"
+	    }
+	    gdb_assert { $total == $running + $sstep + $stopped } \
+		"info waves counts sum to total"
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: before GPU activity.
+# ---------------------------------------------------------------------------
+
+proc test_before_gpu_activity {} {
+    clean_restart $::testfile
+    if { ![runto_main] } {
+	return
+    }
+    gdb_test "info waves" \
+	"0 waves \\(0 running, 0 single-stepping, 0 stopped\\)" \
+	"info waves before GPU activity"
+    gdb_test "info waves count" "0" \
+	"info waves count before GPU activity"
+
+    # Invalid/non-existent inferior numbers.
+    gdb_test "info waves 0" "No inferior number 0\\." \
+	"info waves with inferior 0"
+    gdb_test "info waves count 0" "No inferior number 0\\." \
+	"info waves count with inferior 0"
+    gdb_test "info waves 99" "No inferior number 99\\." \
+	"info waves with inferior 99"
+    gdb_test "info waves count 99" "No inferior number 99\\." \
+	"info waves count with inferior 99"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: all-stop at kernel_bp.
+# Both waves are stopped (all-stop halts everything).
+# ---------------------------------------------------------------------------
+
+proc test_at_kernel_bp {} {
+    clean_restart $::testfile
+    if { ![runto_main] } {
+	return
+    }
+    gdb_breakpoint "kernel_bp" -allow-pending
+    gdb_test_multiple "continue" "continue to kernel_bp" {
+	-re -wrap ".*hit Breakpoint.*kernel_bp.*" {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+    cli_check_waves 2 0
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: non-stop at kernel_bp.
+# One wave is stopped at the breakpoint; the other is still spinning.
+# Also exercises single-stepping observation via async stepi.
+# ---------------------------------------------------------------------------
+
+proc test_nonstop {} {
+    save_vars { ::GDBFLAGS } {
+	append ::GDBFLAGS " -ex \"set non-stop on\""
+	clean_restart $::testfile
+    }
+    if { ![runto_main] } {
+	return
+    }
+    gdb_test "show non-stop" \
+	"Controlling the inferior in non-stop mode is on.*" \
+	"non-stop mode is on"
+    gdb_breakpoint "kernel_bp" -allow-pending
+    gdb_test "continue &" "Continuing\\." "continue async"
+
+    set stopped_thread 0
+    gdb_test_multiple "" "hit kernel_bp" -lbl {
+	-re "Thread ($::decimal)\[^\r\n\]* hit Breakpoint\[^\r\n\]*, kernel_bp " {
+	    set stopped_thread $expect_out(1,string)
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+
+    cli_check_waves 2 1
+
+    # Single-stepping: issue 1000 async steps and poll until a
+    # single-stepping wave is observed.
+    gdb_test "thread $stopped_thread" \
+	"Switching to thread $stopped_thread.*" \
+	"switch to stopped wave thread"
+    gdb_test "stepi 1000 &" "" "start async single-stepping"
+    set found_sstep 0
+    with_test_prefix "poll for single-stepping wave" {
+	for {set i 0} {$i < 20 && $found_sstep == 0} {incr i} {
+	    gdb_test_multiple "info waves" "attempt $i" {
+		-re -wrap "($::decimal) waves \\(($::decimal) running,\
+			   ($::decimal) single-stepping,\
+			   ($::decimal) stopped\\)" {
+		    if { $expect_out(3,string) >= 1 } {
+			set found_sstep 1
+		    }
+		    pass $gdb_test_name
+		}
+		timeout {
+		    fail "$gdb_test_name (timeout)"
+		}
+	    }
+	}
+    }
+    gdb_assert { $found_sstep } "observed at least one single-stepping wave"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: multi-inferior non-stop.
+# Two inferiors each stop at kernel_bp.  Tests the [INF-NUM] argument.
+# Requires multi-process GPU debug support.
+# ---------------------------------------------------------------------------
+
+proc test_multi_inferior {} {
+    save_vars { ::GDBFLAGS } {
+	append ::GDBFLAGS " -ex \"set non-stop on\""
+	clean_restart $::testfile
+    }
+    if { ![runto_main] } {
+	return
+    }
+    gdb_test "add-inferior" "Added inferior 2.*" "add inferior 2"
+    gdb_test "inferior 2" "Switching to inferior 2.*" "switch to inferior 2"
+    gdb_load $::binfile
+    if { ![runto_main] } {
+	return
+    }
+    gdb_breakpoint "kernel_bp" -allow-pending
+    gdb_test_multiple "continue -a &" "continue both inferiors" {
+	-re "Continuing\\.\r\n$::gdb_prompt " {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+
+    set stopped_infs [list]
+    set test "wait for both inferiors at kernel_bp"
+    gdb_test_multiple "" $test -lbl {
+	-re "Thread ($::decimal)\\.$::decimal\[^\r\n\]* hit Breakpoint\[^\r\n\]*, kernel_bp " {
+	    set inf $expect_out(1,string)
+	    if { [lsearch -exact $stopped_infs $inf] == -1 } {
+		lappend stopped_infs $inf
+	    }
+	    if { [llength $stopped_infs] < 2 } {
+		exp_continue
+	    } else {
+		pass $test
+	    }
+	}
+	timeout {
+	    fail "$test (timeout)"
+	}
+    }
+
+    # From inferior 1, query current inferior and inferior 2 by number.
+    gdb_test "inferior 1" "Switching to inferior 1.*" \
+	"switch to inferior 1 for cross-inferior query"
+    with_test_prefix "current inferior 1" {
+	cli_check_waves 1 0
+    }
+    with_test_prefix "non-current inferior 2" {
+	cli_check_waves 1 0 2
+    }
+}
+
+with_rocm_gpu_lock {
+    with_test_prefix "before-gpu" {
+	test_before_gpu_activity
+    }
+    with_test_prefix "all-stop" {
+	test_at_kernel_bp
+    }
+    with_test_prefix "non-stop" {
+	test_nonstop
+    }
+
+    if { [allow_multi_inferior_tests] \
+	     && [hip_devices_support_debug_multi_process] } {
+	with_test_prefix "multi-inferior" {
+	    test_multi_inferior
+	}
+    }
+}

--- a/gdb/testsuite/gdb.rocm/info-waves-mi.exp
+++ b/gdb/testsuite/gdb.rocm/info-waves-mi.exp
@@ -1,0 +1,309 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test the -wave-info and -wave-count MI commands.
+#
+# -wave-count and -wave-info are AMDGPU-specific MI commands available only in
+# ROCgdb.  The ROCm-extended mi_expect_stop already handles AMDGPU-specific
+# *stopped fields (hit-lanes, lane-id) as optional elements.
+
+load_lib rocm.exp
+load_lib mi-support.exp
+
+require allow_hip_tests
+
+standard_testfile info-waves.cpp
+
+if { [prepare_for_testing "failed to prepare ${testfile}" $testfile $srcfile \
+	{ debug hip }] } {
+    return -1
+}
+
+# Check -wave-count and -wave-info MI output.  MIN_TOTAL is the minimum
+# acceptable count.  EXPECT_RUNNING is 1 if the running field must be >= 1.
+#
+# Pattern structure note: each gdb_test_multiple below uses exp_continue after
+# matching the ^done response line, then passes only when "(gdb)" is seen.
+# This is required for correctness under the read1 board, where expect reads
+# one character at a time.  Without consuming through the prompt,
+# gdb_test_multiple returns while "(gdb)" is still in the expect buffer.  The
+# very next gdb_test_multiple then sees "\r\n(gdb)" in the buffer before any
+# output from the new command, which matches the infrastructure pattern that
+# gdb_test_multiple adds to catch blank prompt lines, causing a spurious FAIL.
+#
+# In nonstop mode, async notifications such as *running or =breakpoint-modified
+# can appear between ^done and (gdb), so both cannot be anchored in a single
+# pattern.  The exp_continue approach handles allstop and nonstop uniformly.
+#
+# Note: "[(]gdb[)]" cannot be used inside a gdb_test_multiple script block
+# because "[...]" is Tcl command substitution.  Use "\\(gdb\\)" instead.
+proc mi_check_waves { min_total expect_running } {
+    set wave_count 0
+    gdb_test_multiple "-wave-count" "-wave-count" {
+	-re "\\^done,count=\"(\[0-9\]+)\"" {
+	    set wave_count $expect_out(1,string)
+	    gdb_assert { $wave_count >= $min_total } "-wave-count >= $min_total"
+	    exp_continue
+	}
+	-re "\\(gdb\\)" {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+    gdb_test_multiple "-wave-info" "-wave-info" {
+	-re "\\^done,total=\"(\[0-9\]+)\",running=\"(\[0-9\]+)\",single-stepping=\"(\[0-9\]+)\",stopped=\"(\[0-9\]+)\"" {
+	    set total   $expect_out(1,string)
+	    set running $expect_out(2,string)
+	    set sstep   $expect_out(3,string)
+	    set stopped $expect_out(4,string)
+	    gdb_assert { $total == $wave_count } \
+		"-wave-info total matches -wave-count"
+	    if { $expect_running } {
+		gdb_assert { $running >= 1 } "at least one wave is running (MI)"
+	    }
+	    if { $min_total >= 1 } {
+		gdb_assert { $stopped >= 1 } "at least one wave is stopped (MI)"
+	    }
+	    gdb_assert { $total == $running + $sstep + $stopped } \
+		"-wave-info counts sum to total"
+	    exp_continue
+	}
+	-re "\\(gdb\\)" {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: before GPU activity.
+# ---------------------------------------------------------------------------
+
+proc test_before_gpu_activity {} {
+    if { [mi_clean_restart $::testfile] } {
+	return
+    }
+    if { [mi_runto_main] < 0 } {
+	return
+    }
+    mi_gdb_test "-wave-count" \
+	"\\^done,count=\"0\"" \
+	"-wave-count before GPU activity"
+    mi_gdb_test "-wave-info" \
+	"\\^done,total=\"0\",running=\"0\",single-stepping=\"0\",stopped=\"0\"" \
+	"-wave-info before GPU activity"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: all-stop at kernel_bp.
+# Both waves are stopped (all-stop halts everything).
+# ---------------------------------------------------------------------------
+
+proc test_at_kernel_bp {} {
+    if { [mi_clean_restart $::testfile] } {
+	return
+    }
+    if { [mi_runto_main] < 0 } {
+	return
+    }
+    mi_create_breakpoint_pending "-f kernel_bp" "set breakpoint at kernel_bp"
+    mi_send_resuming_command "exec-continue" "continue to kernel_bp"
+    mi_expect_stop "breakpoint-hit" "kernel_bp" "" ".*" ".*" \
+	{ "" "disp=\"keep\"" } "stop at kernel_bp"
+    mi_check_waves 2 0
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: non-stop at kernel_bp.
+# One wave is stopped at the breakpoint; the other is still spinning.
+# Also exercises single-stepping observation via async stepi.
+# ---------------------------------------------------------------------------
+
+proc test_nonstop {} {
+    save_vars { ::GDBFLAGS } {
+	append ::GDBFLAGS " -ex \"set non-stop on\""
+	mi_clean_restart $::testfile
+    }
+    mi_gdb_test "-gdb-set mi-async 1" "\\^done" "enable MI async"
+    mi_detect_async
+    if { [mi_runto_main] < 0 } {
+	return
+    }
+    mi_create_breakpoint_pending "-f kernel_bp" "set breakpoint at kernel_bp"
+    if { [mi_send_resuming_command "exec-continue" "continue async"] != 0 } {
+	return
+    }
+    # Capture the stopped thread-id from the *stopped event so we can
+    # single-step it below.  mi_expect_stop does not return thread-id.
+    gdb_expect {
+	-re "\\*stopped,reason=\"breakpoint-hit\",\[^\n\]*func=\"kernel_bp\"\[^\n\]*thread-id=\"($::decimal)\"" {
+	    set stopped_tid $expect_out(1,string)
+	    pass "stop at kernel_bp"
+	}
+	timeout {
+	    fail "stop at kernel_bp (timeout)"
+	    return
+	}
+    }
+    mi_check_waves 2 1
+
+    # Exercise the single-stepping state: select the stopped GPU thread and
+    # queue a large async stepi so the wave stays in single-stepping state
+    # long enough to observe with -wave-info.
+    # Each gdb_test_multiple uses exp_continue to drain through the "(gdb)"
+    # prompt before returning.  See the mi_check_waves comment for why this
+    # matters under the read1 board.
+    gdb_test_multiple "-interpreter-exec console \"thread $stopped_tid\"" \
+	"switch to stopped wave thread" {
+	-re "\\^done" {
+	    exp_continue
+	}
+	-re "\\(gdb\\)" {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+    # stepi N & is async: GDB emits ^running followed by *running.
+    gdb_test_multiple "-interpreter-exec console \"stepi 1000 &\"" \
+	"start async single-stepping" {
+	-re "\\^running" {
+	    exp_continue
+	}
+	-re "\\(gdb\\)" {
+	    pass $gdb_test_name
+	}
+	timeout {
+	    fail "$gdb_test_name (timeout)"
+	}
+    }
+    set found_sstep 0
+    set consec_timeouts 0
+    with_test_prefix "poll for single-stepping wave" {
+	save_vars { timeout } {
+	    set timeout 3
+	    for {set i 0} {$i < 20 && $found_sstep == 0 \
+			       && $consec_timeouts < 3} {incr i} {
+		gdb_test_multiple "-wave-info" "attempt $i" {
+		    -re "\\^done,total=\"$::decimal\",running=\"$::decimal\",single-stepping=\"($::decimal)\",stopped=\"$::decimal\"" {
+			if { $expect_out(1,string) >= 1 } {
+			    set found_sstep 1
+			}
+			set consec_timeouts 0
+			exp_continue
+		    }
+		    -re "\\(gdb\\)" {
+			pass $gdb_test_name
+		    }
+		    timeout {
+			incr consec_timeouts
+			fail "$gdb_test_name (timeout)"
+		    }
+		}
+	    }
+	}
+    }
+    gdb_assert { $found_sstep } "observed at least one single-stepping wave (MI)"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: multi-inferior non-stop.
+# MI commands always query the current inferior.  Two inferiors each stop at
+# kernel_bp.  Requires multi-process GPU debug support.
+# ---------------------------------------------------------------------------
+
+proc test_multi_inferior {} {
+    save_vars { ::GDBFLAGS } {
+	append ::GDBFLAGS " -ex \"set non-stop on\""
+	mi_clean_restart $::testfile
+    }
+    mi_gdb_test "-gdb-set mi-async 1" "\\^done" "enable MI async"
+    mi_detect_async
+    if { [mi_runto_main] < 0 } {
+	return
+    }
+    # Add inferior 2 and load the binary into it.
+    # -add-inferior response includes a connection field; match flexibly.
+    mi_gdb_test "-add-inferior" \
+	"\\^done,inferior=\"i2\".*" "add inferior 2"
+    mi_gdb_test "-interpreter-exec console \"inferior 2\"" \
+	".*\\^done" "select inferior 2"
+    mi_gdb_test "-file-exec-and-symbols $::binfile" "\\^done" \
+	"load binary in inferior 2"
+    # Run inferior 2 to main.  With both inferiors sharing the same binary the
+    # temporary breakpoint resolves in both and gets addr="<MULTIPLE>", so
+    # match flexibly and pass locno to mi_expect_stop.
+    mi_gdb_test "220-break-insert --qualified -t main" \
+	"220\\^done,bkpt=.*" "breakpoint at main for inferior 2"
+    if { [mi_run_cmd] < 0 } {
+	return
+    }
+    mi_expect_stop "breakpoint-hit" "main" ".*" ".*" "${::decimal}" \
+	[list "" "disp=\"del\"" "locno=\"$::decimal\""] \
+	"mi runto main for inferior 2"
+    mi_create_breakpoint_pending "-f kernel_bp" "set breakpoint at kernel_bp"
+    # mi_send_resuming_command expects only one *running event.  With two
+    # inferiors, two are emitted; match them directly with mi_gdb_test.
+    mi_gdb_test "-exec-continue --all" \
+	"\\^running(\r\n\\*running,thread-id=\"\[^\"\]+\")+" \
+	"continue both inferiors"
+    # Wait for both inferiors to stop at kernel_bp.  Between and after the two
+    # *stopped events GDB emits =breakpoint-modified and =thread-created lines
+    # that mi_expect_stop cannot skip, so count stops with gdb_expect directly.
+    set stopped_count 0
+    set test "both inferiors stop at kernel_bp"
+    gdb_expect {
+	-re "\\*stopped,reason=\"breakpoint-hit\",\[^\n\]*func=\"kernel_bp\"\[^\n\]*\n" {
+	    incr stopped_count
+	    if { $stopped_count < 2 } {
+		exp_continue
+	    } else {
+		pass $test
+	    }
+	}
+	timeout {
+	    fail "$test (timeout, got $stopped_count of 2 stops)"
+	}
+    }
+    # -wave-info and -wave-count query the current inferior.
+    mi_check_waves 1 0
+}
+
+with_rocm_gpu_lock {
+    with_test_prefix "before-gpu" {
+	test_before_gpu_activity
+    }
+    with_test_prefix "all-stop" {
+	test_at_kernel_bp
+    }
+    with_test_prefix "non-stop" {
+	test_nonstop
+    }
+
+    if { [allow_multi_inferior_tests] \
+	     && [hip_devices_support_debug_multi_process] } {
+	with_test_prefix "multi-inferior" {
+	    test_multi_inferior
+	}
+    }
+}

--- a/gdb/testsuite/gdb.rocm/info-waves.cpp
+++ b/gdb/testsuite/gdb.rocm/info-waves.cpp
@@ -1,0 +1,70 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <hip/hip_runtime.h>
+
+#define CHECK(cmd)							  \
+  do									  \
+    {									  \
+      hipError_t error = cmd;						  \
+      if (error != hipSuccess)						  \
+	{								  \
+	  fprintf (stderr, "error: '%s'(%d) at %s:%d\n",		  \
+		   hipGetErrorString (error), error, __FILE__, __LINE__); \
+	  exit (EXIT_FAILURE);						  \
+	}								  \
+    }									  \
+  while (0)
+
+__device__ static bool lock = true;
+
+/* The first block breaks here while the second block is still spinning,
+   giving a mix of stopped and running waves visible to "info waves" in
+   non-stop mode.  */
+/* optnone implies noinline and keeps the body opaque to the optimizer,
+   so the breakpoint reliably fires even at -O3.  */
+__device__ __attribute__ ((optnone)) void
+kernel_bp ()
+{
+}
+
+__global__ void
+kernel ()
+{
+  while (__hip_atomic_load (&lock, __ATOMIC_RELAXED,
+			    __HIP_MEMORY_SCOPE_AGENT))
+    {
+      /* Block 0 is the breakpoint block.  It calls kernel_bp and then
+	 releases the lock so the other block exits the spin loop.  */
+      if (blockIdx.x == 0)
+	{
+	  kernel_bp ();
+	  __hip_atomic_store (&lock, false, __ATOMIC_RELAXED,
+			      __HIP_MEMORY_SCOPE_AGENT);
+	}
+      __builtin_amdgcn_s_sleep (1);
+    }
+}
+
+int
+main ()
+{
+  kernel<<<2, 1>>> ();
+  CHECK (hipDeviceSynchronize ());
+  return 0;
+}

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -420,14 +420,14 @@ proc gdb_compile_ocl {source dest type options} {
     return $result
 }
 
-# Run "info threads INF_NUM", return the number of "AMDGPU Wave" threads found.
+# Return the wave count for inferior INF_NUM via "info waves count INF_NUM".
 
 proc info_threads_get_wave_count { inf_num } {
     set wave_count 0
-    gdb_test_multiple "info threads ${inf_num}.*" "" {
-	-re "AMDGPU Wave\[^\r\n\]+\r\n" {
-	    incr wave_count
-	    exp_continue
+    gdb_test_multiple "info waves count ${inf_num}" "" {
+	-re "($::decimal)\r\n$::gdb_prompt " {
+	    set wave_count $expect_out(1,string)
+	    pass $gdb_test_name
 	}
 
 	-re "$::gdb_prompt " {


### PR DESCRIPTION
Add CLI commands "info waves" and "info waves count" and their MI
equivalents -wave-info and -wave-count for querying GPU wave state.

"info waves [INF]" displays a summary of active waves broken down by
state (running, single-stepping, stopped) for the given inferior, or
the current inferior if omitted.  "info waves count [INF]" displays just
the total wave count.  The optional inferior number argument allows
cross-inferior queries in non-stop sessions without switching inferiors.

The MI commands always query the current inferior.

Includes documentation and tests across four scenarios: before GPU
activity, all-stop, non-stop with single-stepping, and multi-inferior
non-stop.

## Test plan

- [ ] info-waves-cli.exp passes (all-stop, non-stop, multi-inferior)
- [ ] info-waves-mi.exp passes (all-stop, non-stop, multi-inferior)
- [ ] Existing tests that use info_threads_get_wave_count still pass