### PR TITLE
[amd-staging-rocgdb-16] ROCgdb cherry picks from origin/amd-staging (2026-09-10)

### DIFF
--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,6 +1,6 @@
 {
-  "therock_commit_ref": "32d9f40dcef777bd947868b0f6b20c1cbae53867",
-  "therock_commit_created": "2026-09-05T12:40:47Z",
+  "therock_commit_ref": "8943c0144e06812796c904cef6fc4a59c538d768",
+  "therock_commit_created": "2026-09-08T23:41:42Z",
   "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:cf4f6d9909056906e4a1c0bc4c245658a0af4c6a6174082a86adfa2d518b7aeb",
   "build_image_created": "2026-08-17T22:45:41.087330949Z"
 }

--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,6 +1,6 @@
 {
-  "therock_commit_ref": "d0a3a81db89bb08ce904253bd1e455b0e070d596",
-  "therock_commit_created": "2026-09-02T03:29:20Z",
+  "therock_commit_ref": "32d9f40dcef777bd947868b0f6b20c1cbae53867",
+  "therock_commit_created": "2026-09-05T12:40:47Z",
   "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:cf4f6d9909056906e4a1c0bc4c245658a0af4c6a6174082a86adfa2d518b7aeb",
   "build_image_created": "2026-08-17T22:45:41.087330949Z"
 }

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1903,7 +1903,11 @@ amdgpu_get_watchable_aliases (struct gdbarch *gdbarch,
       /* Try to convert the address to an address in the
 	 default address space.  */
       if (amd_dbgapi_convert_address_space
-	    (wave_id, simd_lane, dbgapi_from_addr_space_id,
+	    (
+#if AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID
+	     get_amd_dbgapi_process_id (current_inferior ()),
+#endif
+	     wave_id, simd_lane, dbgapi_from_addr_space_id,
 	     (amd_dbgapi_segment_address_t) addr,
 	     dbgapi_to_addr_space_id, &to_offset, &converted_size)
 	    != AMD_DBGAPI_STATUS_SUCCESS)

--- a/gdb/config.in
+++ b/gdb/config.in
@@ -6,6 +6,9 @@
 /* Additional directories to look for separate debug info. */
 #undef ADDITIONAL_DEBUG_DIRS
 
+/* Define if amd_dbgapi_convert_address_space needs a process_id */
+#undef AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID
+
 /* Directories from which to load auto-loaded scripts. */
 #undef AUTO_LOAD_DIR
 

--- a/gdb/configure
+++ b/gdb/configure
@@ -25160,6 +25160,46 @@ $as_echo "#define HAVE_AMD_DBGAPI 1" >>confdefs.h
     if test "$all_targets" = true; then
       TARGET_OBS="$TARGET_OBS \$(ALL_AMD_DBGAPI_TARGET_OBS)"
     fi
+
+    # Detect if process id can be passed to convert_address_space.
+    save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $AMD_DBGAPI_CFLAGS"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether amd_dbgapi_convert_address_space takes a process id" >&5
+$as_echo_n "checking whether amd_dbgapi_convert_address_space takes a process id... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <amd-dbgapi/amd-dbgapi.h>
+int
+main ()
+{
+amd_dbgapi_process_id_t p;
+	  amd_dbgapi_wave_id_t w;
+	  amd_dbgapi_lane_id_t l;
+	  amd_dbgapi_address_space_id_t s, d;
+	  amd_dbgapi_convert_address_space (p, w, l, s, 0, d, NULL, NULL);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  amd_dbgapi_convert_aspace_needs_process_id=yes
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  amd_dbgapi_convert_aspace_needs_process_id=no
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CPPFLAGS="$save_CPPFLAGS"
+
+    if test "x${amd_dbgapi_convert_aspace_needs_process_id}" = "xyes"; then
+
+$as_echo "#define AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID 1" >>confdefs.h
+
+    fi
+
   elif test "$gdb_require_amd_dbgapi" = true -o "$with_amd_dbgapi" = yes; then
     # amd-dbgapi was not found and...
     #

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -306,6 +306,31 @@ if test "$gdb_require_amd_dbgapi" = true \
     if test "$all_targets" = true; then
       TARGET_OBS="$TARGET_OBS \$(ALL_AMD_DBGAPI_TARGET_OBS)"
     fi
+
+    # Detect if process id can be passed to convert_address_space.
+    save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $AMD_DBGAPI_CFLAGS"
+    AC_MSG_CHECKING([whether amd_dbgapi_convert_address_space takes a process id])
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+	[[#include <amd-dbgapi/amd-dbgapi.h>]],
+	[[amd_dbgapi_process_id_t p;
+	  amd_dbgapi_wave_id_t w;
+	  amd_dbgapi_lane_id_t l;
+	  amd_dbgapi_address_space_id_t s, d;
+	  amd_dbgapi_convert_address_space (p, w, l, s, 0, d, NULL, NULL);]]
+       )],
+       [amd_dbgapi_convert_aspace_needs_process_id=yes
+	AC_MSG_RESULT([yes])],
+       [amd_dbgapi_convert_aspace_needs_process_id=no
+	AC_MSG_RESULT([no])])
+    CPPFLAGS="$save_CPPFLAGS"
+
+    if test "x${amd_dbgapi_convert_aspace_needs_process_id}" = "xyes"; then
+      AC_DEFINE(AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID, 1,
+		[Define if amd_dbgapi_convert_address_space needs a process_id])
+    fi
+
   elif test "$gdb_require_amd_dbgapi" = true -o "$with_amd_dbgapi" = yes; then
     # amd-dbgapi was not found and...
     #

--- a/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
+++ b/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
@@ -40,6 +40,31 @@ if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
     return
 }
 
+# On gfx1151, hipLaunchCooperativeKernel fails under the debugger
+# with HIP error 401.  KFD refuses GWS allocation while debug trap
+# is enabled.  The program works without GDB so this is an expected
+# failure rather than UNSUPPORTED.  Drop the xfail once a kernel
+# with the GWS debug fix is in use.
+
+proc target_has_xfail {} {
+    set xfail_arches {gfx1151}
+
+    set targets [find_amdgpu_devices]
+    if {[llength $targets] == 0} {
+	return 0
+    }
+
+    # The test runs on the first visible HIP device.
+    set target [lindex $targets 0]
+    return [expr {[lsearch -exact $xfail_arches $target] != -1}]
+}
+
+proc maybe_xfail {} {
+    if {[target_has_xfail]} {
+	setup_xfail "*-*-*" "AIROCGDB-654"
+    }
+}
+
 # Test debugging a single-device cooperative kernel.  Stop at a
 # breakpoint after grid.sync () -- which fires once all waves have
 # crossed the GWS barrier, proving GWS-protected code can be debugged
@@ -63,6 +88,7 @@ proc_with_prefix test_coop_grid_sync {} {
 	# Continue into the kernel.  If the program self-skips (no device
 	# advertises cooperativeLaunch) it exits cleanly; treat that as
 	# UNSUPPORTED rather than a FAIL.
+	maybe_xfail
 	set reached 0
 	gdb_test_multiple "continue" "stop after grid.sync" {
 	    -re -wrap "Temporary breakpoint $::decimal,\[^\r\n\]*coop_grid_sync_kernel .*" {

--- a/gdb/testsuite/gdb.rocm/resume-exception.exp
+++ b/gdb/testsuite/gdb.rocm/resume-exception.exp
@@ -122,11 +122,15 @@ proc interrupt_running_threads { } {
 with_rocm_gpu_lock {
     # Run to GPU thread.
     gdb_breakpoint "raise_fpe" "allow-pending"
+    set gpu_thread "invalid"
     gdb_test_multiple "run" "" {
 	-re -wrap ".*Thread ($::decimal) \[^\r\n]* hit Breakpoint .*" {
 	    set gpu_thread $expect_out(1,string)
 	    pass $gdb_test_name
 	}
+    }
+    if {$gpu_thread eq "invalid"} {
+	return
     }
     gdb_test "thread $gpu_thread" "raise_fpe.*" "select GPU thread"
 


### PR DESCRIPTION
e49503e55e3 Update TheRock dependencies and container images
5cfc01df00e Update TheRock dependencies and container images
458476c89de gdb.rocm: xfail coop-group-grid-sync on gfx1151
e5630fed617 gdb/testsuite: resume-exception.exp: Handle failure to hit breakpoint
8ac7095cbf6 gdb, amdgpu: pass process id to amd_dbgapi_convert_address_space
