### PR TITLE
[amd-staging-rocgdb-18] ROCgdb cherry picks from origin/amd-staging (2026-09-10)

### DIFF
--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,6 +1,6 @@
 {
-  "therock_commit_ref": "32d9f40dcef777bd947868b0f6b20c1cbae53867",
-  "therock_commit_created": "2026-09-05T12:40:47Z",
+  "therock_commit_ref": "8943c0144e06812796c904cef6fc4a59c538d768",
+  "therock_commit_created": "2026-09-08T23:41:42Z",
   "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:cf4f6d9909056906e4a1c0bc4c245658a0af4c6a6174082a86adfa2d518b7aeb",
   "build_image_created": "2026-08-17T22:45:41.087330949Z"
 }

--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,6 +1,6 @@
 {
-  "therock_commit_ref": "d0a3a81db89bb08ce904253bd1e455b0e070d596",
-  "therock_commit_created": "2026-09-02T03:29:20Z",
+  "therock_commit_ref": "32d9f40dcef777bd947868b0f6b20c1cbae53867",
+  "therock_commit_created": "2026-09-05T12:40:47Z",
   "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:cf4f6d9909056906e4a1c0bc4c245658a0af4c6a6174082a86adfa2d518b7aeb",
   "build_image_created": "2026-08-17T22:45:41.087330949Z"
 }

--- a/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
+++ b/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
@@ -40,6 +40,31 @@ if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
     return
 }
 
+# On gfx1151, hipLaunchCooperativeKernel fails under the debugger
+# with HIP error 401.  KFD refuses GWS allocation while debug trap
+# is enabled.  The program works without GDB so this is an expected
+# failure rather than UNSUPPORTED.  Drop the xfail once a kernel
+# with the GWS debug fix is in use.
+
+proc target_has_xfail {} {
+    set xfail_arches {gfx1151}
+
+    set targets [find_amdgpu_devices]
+    if {[llength $targets] == 0} {
+	return 0
+    }
+
+    # The test runs on the first visible HIP device.
+    set target [lindex $targets 0]
+    return [expr {[lsearch -exact $xfail_arches $target] != -1}]
+}
+
+proc maybe_xfail {} {
+    if {[target_has_xfail]} {
+	setup_xfail "*-*-*" "AIROCGDB-654"
+    }
+}
+
 # Test debugging a single-device cooperative kernel.  Stop at a
 # breakpoint after grid.sync () -- which fires once all waves have
 # crossed the GWS barrier, proving GWS-protected code can be debugged
@@ -63,6 +88,7 @@ proc_with_prefix test_coop_grid_sync {} {
 	# Continue into the kernel.  If the program self-skips (no device
 	# advertises cooperativeLaunch) it exits cleanly; treat that as
 	# UNSUPPORTED rather than a FAIL.
+	maybe_xfail
 	set reached 0
 	gdb_test_multiple "continue" "stop after grid.sync" {
 	    -re -wrap "Temporary breakpoint $::decimal,\[^\r\n\]*coop_grid_sync_kernel .*" {

--- a/gdb/testsuite/gdb.rocm/resume-exception.exp
+++ b/gdb/testsuite/gdb.rocm/resume-exception.exp
@@ -123,11 +123,15 @@ proc interrupt_running_threads { } {
 with_rocm_gpu_lock {
     # Run to GPU thread.
     gdb_breakpoint "raise_fpe" -allow-pending
+    set gpu_thread "invalid"
     gdb_test_multiple "run" "" {
 	-re -wrap ".*Thread ($::decimal) \[^\r\n]* hit Breakpoint .*" {
 	    set gpu_thread $expect_out(1,string)
 	    pass $gdb_test_name
 	}
+    }
+    if {$gpu_thread eq "invalid"} {
+	return
     }
     gdb_test "thread $gpu_thread" "raise_fpe.*" "select GPU thread"
 


### PR DESCRIPTION
263dab3ea95 Update TheRock dependencies and container images
a3570815690 Update TheRock dependencies and container images
a7c3be9f8bc gdb.rocm: xfail coop-group-grid-sync on gfx1151
0214aff366d gdb/testsuite: resume-exception.exp: Handle failure to hit breakpoint
