### PR TITLE
gdb: Add generic AMDGPU target testing support

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1762,10 +1762,26 @@ amdgpu_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
     = amdgpu_segment_address_from_core_address (address);
 
   amd_dbgapi_architecture_id_t architecture_id;
-  if (amd_dbgapi_get_architecture
-      (gdbarch_bfd_arch_info (gdbarch)->mach, &architecture_id)
-      != AMD_DBGAPI_STATUS_SUCCESS)
-    error (_("amd_dbgapi_get_architecture failed"));
+  if (ptid_is_gpu (ptid))
+    {
+      /* We have a concrete wave, use the wave's architecture.  */
+      amd_dbgapi_wave_id_t wave_id = get_amd_dbgapi_wave_id (ptid);
+
+      if (amd_dbgapi_wave_get_info (wave_id,
+				    AMD_DBGAPI_WAVE_INFO_ARCHITECTURE,
+				    sizeof (architecture_id),
+				    &architecture_id)
+	  != AMD_DBGAPI_STATUS_SUCCESS)
+	error (_("amd_dbgapi_wave_get_info failed"));
+
+    }
+  else
+    {
+      if (amd_dbgapi_get_architecture
+	  (gdbarch_bfd_arch_info (gdbarch)->mach, &architecture_id)
+	  != AMD_DBGAPI_STATUS_SUCCESS)
+	error (_("amd_dbgapi_get_architecture failed"));
+    }
 
   amd_dbgapi_address_space_id_t address_space_id;
   if (amd_dbgapi_dwarf_address_space_to_address_space (architecture_id,

--- a/gdb/testsuite/boards/rocm-generic.exp
+++ b/gdb/testsuite/boards/rocm-generic.exp
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Board file: run the gdb.rocm/ testsuite with generic AMDGPU code
+# objects.  Each concrete arch detected at runtime is replaced by its
+# generic equivalent (e.g. gfx942 -> gfx9-4-generic).  Tests are
+# skipped as normal when no GPU is present or no generic target exists
+# for the detected hardware.
+#
+# Usage: make check RUNTESTFLAGS="--target_board=rocm-generic"
+
+load_lib rocm.exp
+load_generic_config "unix"
+load_board_description "local-board"
+
+# Tell hcc_amdgpu_targets to map concrete arches to their generic
+# equivalents.  The flag is checked inside hcc_amdgpu_targets in
+# rocm.exp so the proc itself is not renamed or replaced, keeping unit
+# tests that call it directly unaffected.
+set ::rocm_use_generic_targets 1

--- a/gdb/testsuite/gdb.rocm/hcc-amdgpu-targets.exp
+++ b/gdb/testsuite/gdb.rocm/hcc-amdgpu-targets.exp
@@ -34,8 +34,11 @@ proc with_stub_devices {devices body} {
 }
 
 # Tests using find_amdgpu_devices (no HCC_AMDGPU_TARGET env var).
+# Disable generic-target mapping for the duration of this file so that
+# the deduplication logic is tested against concrete arch names.
 
-save_vars { env(HCC_AMDGPU_TARGET) } {
+save_vars { env(HCC_AMDGPU_TARGET) ::rocm_use_generic_targets } {
+    set ::rocm_use_generic_targets 0
     unset -nocomplain ::env(HCC_AMDGPU_TARGET)
 
     with_stub_devices {gfx942 gfx942 gfx942} {
@@ -65,14 +68,16 @@ save_vars { env(HCC_AMDGPU_TARGET) } {
 
 # Tests using HCC_AMDGPU_TARGET env var.
 
-save_vars { env(HCC_AMDGPU_TARGET) } {
+save_vars { env(HCC_AMDGPU_TARGET) ::rocm_use_generic_targets } {
+    set ::rocm_use_generic_targets 0
     set ::env(HCC_AMDGPU_TARGET) "gfx942,gfx942,gfx942"
     set result [hcc_amdgpu_targets]
     verbose -log "hcc_amdgpu_targets: got $result"
     gdb_assert {$result eq {gfx942}} "env var: duplicates removed"
 }
 
-save_vars { env(HCC_AMDGPU_TARGET) } {
+save_vars { env(HCC_AMDGPU_TARGET) ::rocm_use_generic_targets } {
+    set ::rocm_use_generic_targets 0
     set ::env(HCC_AMDGPU_TARGET) "gfx906,gfx90a,gfx906"
     set result [hcc_amdgpu_targets]
     verbose -log "hcc_amdgpu_targets: got $result"

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -101,6 +101,37 @@ gdb_caching_proc find_amdgpu_devices {} {
     return {}
 }
 
+# Return the generic AMDGPU target for ARCH, or "" if no generic target
+# exists for it.
+
+proc generic_target_for { arch } {
+    array set map {
+	gfx900 gfx9-generic    gfx902 gfx9-generic
+	gfx904 gfx9-generic    gfx906 gfx9-generic
+	gfx909 gfx9-generic    gfx90c gfx9-generic
+	gfx942 gfx9-4-generic  gfx950 gfx9-4-generic
+	gfx1010 gfx10-1-generic  gfx1011 gfx10-1-generic
+	gfx1012 gfx10-1-generic  gfx1013 gfx10-1-generic
+	gfx1030 gfx10-3-generic  gfx1031 gfx10-3-generic
+	gfx1032 gfx10-3-generic  gfx1033 gfx10-3-generic
+	gfx1034 gfx10-3-generic  gfx1035 gfx10-3-generic
+	gfx1036 gfx10-3-generic
+	gfx1100 gfx11-generic  gfx1101 gfx11-generic
+	gfx1102 gfx11-generic  gfx1103 gfx11-generic
+	gfx1150 gfx11-generic  gfx1151 gfx11-generic
+	gfx1152 gfx11-generic  gfx1153 gfx11-generic
+	gfx1154 gfx11-generic
+	gfx1170 gfx11-7-generic  gfx1171 gfx11-7-generic
+	gfx1172 gfx11-7-generic
+	gfx1200 gfx12-generic  gfx1201 gfx12-generic
+	gfx1250 gfx12-5-generic
+    }
+    if { [info exists map($arch)] } {
+	return $map($arch)
+    }
+    return ""
+}
+
 # Get the list of unique GPU targets to compile for.
 #
 # If HCC_AMDGPU_TARGET is set in the environment, use it.
@@ -128,6 +159,21 @@ proc hcc_amdgpu_targets {} {
 	    lappend unique $t
 	}
     }
+
+    # When the rocm-generic board is active, map each concrete arch to
+    # its generic equivalent and drop any that have no mapping.
+    if { [info exists ::rocm_use_generic_targets] \
+	     && $::rocm_use_generic_targets } {
+	set mapped {}
+	foreach t $unique {
+	    set g [generic_target_for $t]
+	    if { $g ne "" && $g ni $mapped } {
+		lappend mapped $g
+	    }
+	}
+	return $mapped
+    }
+
     return $unique
 }
 


### PR DESCRIPTION
## Summary

- Add \`gdb/testsuite/boards/rocm-generic.exp\`, a new DejaGnu board that runs the \`gdb.rocm/\` testsuite with kernels compiled for generic AMDGPU targets rather than the concrete arch detected on the system (e.g. gfx942 is compiled as \`gfx9-4-generic\`).
- Add \`generic_target_for\` proc to \`gdb/testsuite/lib/rocm.exp\` that maps a concrete gfx arch to its generic equivalent, making the mapping reusable by individual tests.
- Add a \`::rocm_use_generic_targets\` flag consumed by \`hcc_amdgpu_targets\` so the board can activate generic-target substitution without replacing the proc, keeping the \`hcc-amdgpu-targets.exp\` unit test unaffected.
- Fix \`amdgpu_address_scope\` to use the wave's own architecture id when a concrete wave is available, rather than the gdbarch mach of the generic code object. This is required for \`amd_dbgapi_address_dependency\` to succeed when debugging generic code objects on concrete hardware.

Addresses AIROCGDB-660.

## Test plan

- [ ] Run \`make check RUNTESTFLAGS="--target_board=rocm-generic"\` on a system with a GPU that has a known generic target (e.g. gfx942, gfx1100, gfx1030)
- [ ] Verify tests compile against the generic arch and run correctly on the concrete hardware
- [ ] Verify tests are skipped cleanly on hardware with no generic target mapping
- [ ] Verify \`gdb.rocm/hcc-amdgpu-targets.exp\` passes under both the default and \`rocm-generic\` boards